### PR TITLE
Stable OVOS dependencies

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -40,5 +40,7 @@ jobs:
       - uses: pypa/gh-action-pip-audit@v1.0.0
         with:
           # Ignore setuptools vulnerability we can't do much about
+          # Ignore numpy vulnerability affecting latest version for Py3.7
           ignore-vulns: |
             GHSA-r9hx-vwmv-q579
+            GHSA-fpfv-jqm9-f5jm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytz>=2022.1
 tzlocal>=1.3
-timezonefinder
-geocoder
-ovos-utils~=0.0, >=0.0.28a4
-ovos_workshop~=0.0, >=0.0.11a4
+timezonefinder~=5.2
+geocoder~=1.38
+ovos-utils~=0.0, >=0.0.28
+ovos_workshop~=0.0, >=0.0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ timezonefinder~=5.2
 geocoder~=1.38
 ovos-utils~=0.0, >=0.0.28
 ovos_workshop~=0.0, >=0.0.11
-numpy>1.21.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ timezonefinder~=5.2
 geocoder~=1.38
 ovos-utils~=0.0, >=0.0.28
 ovos_workshop~=0.0, >=0.0.11
+numpy!=1.21.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ timezonefinder~=5.2
 geocoder~=1.38
 ovos-utils~=0.0, >=0.0.28
 ovos_workshop~=0.0, >=0.0.11
-numpy!=1.21.6
+numpy>1.21.6


### PR DESCRIPTION
Pin dependencies to troubleshoot pip audit failures (https://github.com/OpenVoiceOS/ovos-core/pull/282)