### PR TITLE
Feat/seperate mk1

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -13,7 +13,7 @@ jobs:
     uses: neongeckocom/.github/.github/workflows/python_build_tests.yml@master
     with:
       test_manifest: true
-      manifest_ignored: "test/**,scripts/**,CHANGELOG.md"
+      manifest_ignored: "test/**,scripts/**,CHANGELOG.md, translations/**"
   pip_audit:
     strategy:
       max-parallel: 2

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -13,7 +13,7 @@ jobs:
     uses: neongeckocom/.github/.github/workflows/python_build_tests.yml@master
     with:
       test_manifest: true
-      manifest_ignored: "test/**,scripts/**,CHANGELOG.md, translations/**"
+      manifest_ignored: "test/**,scripts/**,CHANGELOG.md,translations/**"
   pip_audit:
     strategy:
       max-parallel: 2

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -36,3 +36,4 @@ jobs:
           ignore-vulns: |
             GHSA-r9hx-vwmv-q579
             GHSA-fpfv-jqm9-f5jm
+            PYSEC-2022-43012

--- a/__init__.py
+++ b/__init__.py
@@ -23,11 +23,13 @@ from lingua_franca.parse import extract_datetime, fuzzy_match, normalize
 from timezonefinder import TimezoneFinder
 
 from ovos_utils import classproperty
+from ovos_utils.log import LOG
 from ovos_utils.process_utils import RuntimeRequirements
 from ovos_utils.time import now_local, get_next_leap_year
 from ovos_workshop.decorators import intent_handler
 from ovos_workshop.intents import IntentBuilder
 from ovos_workshop.skills import OVOSSkill
+from ovos_bus_client.message import Message
 
 
 def speakable_timezone(tz):
@@ -444,14 +446,9 @@ class TimeSkill(OVOSSkill):
 
     def show_date_mark1(self, dt: datetime.datetime):
         show = self.get_display_date(anchor_date=dt)
-        # TODO - move to mk1 plugin
+        LOG.debug(f"sending date to mk1 {show}")
         self.bus.emit(Message("ovos.mk1.display_date",
                              {"text": show}))
-        # self.enclosure.deactivate_mouth_events()
-        # self.enclosure.mouth_text(show)
-        # time.sleep(10)
-        # self.enclosure.mouth_reset()
-        # self.enclosure.activate_mouth_events()
 
     def show_date_gui(self, dt: datetime.datetime, location: str):
         self.gui.clear()
@@ -473,56 +470,9 @@ class TimeSkill(OVOSSkill):
         self.show_time_mark1(display_time)
 
     def show_time_mark1(self, display_time: str):
-        # TODO - move to mk1 plugin
+        LOG.debug(f"sending time to mk1 {text}")
         self.bus.emit(Message("ovos.mk1.display_time",
                              {"text": display_time}))
-        # self.enclosure.deactivate_mouth_events()
-        # # Map characters to the display encoding for a Mark 1
-        # # (4x8 except colon, which is 2x8)
-        # code_dict = {
-        #     ':': 'CIICAA',
-        #     '0': 'EIMHEEMHAA',
-        #     '1': 'EIIEMHAEAA',
-        #     '2': 'EIEHEFMFAA',
-        #     '3': 'EIEFEFMHAA',
-        #     '4': 'EIMBABMHAA',
-        #     '5': 'EIMFEFEHAA',
-        #     '6': 'EIMHEFEHAA',
-        #     '7': 'EIEAEAMHAA',
-        #     '8': 'EIMHEFMHAA',
-        #     '9': 'EIMBEBMHAA',
-        # }
-        # 
-        # # clear screen (draw two blank sections, numbers cover rest)
-        # if len(display_time) == 4:
-        #     # for 4-character times, 9x8 blank
-        #     self.enclosure.mouth_display(img_code="JIAAAAAAAAAAAAAAAAAA",
-        #                                  refresh=False)
-        #     self.enclosure.mouth_display(img_code="JIAAAAAAAAAAAAAAAAAA",
-        #                                  x=22, refresh=False)
-        # else:
-        #     # for 5-character times, 7x8 blank
-        #     self.enclosure.mouth_display(img_code="HIAAAAAAAAAAAAAA",
-        #                                  refresh=False)
-        #     self.enclosure.mouth_display(img_code="HIAAAAAAAAAAAAAA",
-        #                                  x=24, refresh=False)
-        # 
-        # # draw the time, centered on display
-        # xoffset = (32 - (4 * (len(display_time)) - 2)) / 2
-        # for c in display_time:
-        #     if c in code_dict:
-        #         self.enclosure.mouth_display(img_code=code_dict[c],
-        #                                      x=xoffset, refresh=False)
-        #         if c == ":":
-        #             xoffset += 2  # colon is 1 pixels + a space
-        #         else:
-        #             xoffset += 4  # digits are 3 pixels + a space
-        # 
-        # self.enclosure.mouth_display(img_code="CIAAAA", x=29,
-        #                              refresh=False)
-        # time.sleep(5)
-        # self.enclosure.mouth_reset()
-        # self.enclosure.activate_mouth_events()
 
     def show_time_gui(self, display_time):
         """ Display time on the GUI. """

--- a/__init__.py
+++ b/__init__.py
@@ -445,13 +445,13 @@ class TimeSkill(OVOSSkill):
     def show_date_mark1(self, dt: datetime.datetime):
         show = self.get_display_date(anchor_date=dt)
         # TODO - move to mk1 plugin
-        #self.bus.emit(Message("ovos.mk1.display_date",
-        #                      {"text": show}))
-        self.enclosure.deactivate_mouth_events()
-        self.enclosure.mouth_text(show)
-        time.sleep(10)
-        self.enclosure.mouth_reset()
-        self.enclosure.activate_mouth_events()
+        self.bus.emit(Message("ovos.mk1.display_date",
+                             {"text": show}))
+        # self.enclosure.deactivate_mouth_events()
+        # self.enclosure.mouth_text(show)
+        # time.sleep(10)
+        # self.enclosure.mouth_reset()
+        # self.enclosure.activate_mouth_events()
 
     def show_date_gui(self, dt: datetime.datetime, location: str):
         self.gui.clear()
@@ -474,55 +474,55 @@ class TimeSkill(OVOSSkill):
 
     def show_time_mark1(self, display_time: str):
         # TODO - move to mk1 plugin
-        #self.bus.emit(Message("ovos.mk1.display_time",
-        #                      {"text": display_time}))
-        self.enclosure.deactivate_mouth_events()
-        # Map characters to the display encoding for a Mark 1
-        # (4x8 except colon, which is 2x8)
-        code_dict = {
-            ':': 'CIICAA',
-            '0': 'EIMHEEMHAA',
-            '1': 'EIIEMHAEAA',
-            '2': 'EIEHEFMFAA',
-            '3': 'EIEFEFMHAA',
-            '4': 'EIMBABMHAA',
-            '5': 'EIMFEFEHAA',
-            '6': 'EIMHEFEHAA',
-            '7': 'EIEAEAMHAA',
-            '8': 'EIMHEFMHAA',
-            '9': 'EIMBEBMHAA',
-        }
-
-        # clear screen (draw two blank sections, numbers cover rest)
-        if len(display_time) == 4:
-            # for 4-character times, 9x8 blank
-            self.enclosure.mouth_display(img_code="JIAAAAAAAAAAAAAAAAAA",
-                                         refresh=False)
-            self.enclosure.mouth_display(img_code="JIAAAAAAAAAAAAAAAAAA",
-                                         x=22, refresh=False)
-        else:
-            # for 5-character times, 7x8 blank
-            self.enclosure.mouth_display(img_code="HIAAAAAAAAAAAAAA",
-                                         refresh=False)
-            self.enclosure.mouth_display(img_code="HIAAAAAAAAAAAAAA",
-                                         x=24, refresh=False)
-
-        # draw the time, centered on display
-        xoffset = (32 - (4 * (len(display_time)) - 2)) / 2
-        for c in display_time:
-            if c in code_dict:
-                self.enclosure.mouth_display(img_code=code_dict[c],
-                                             x=xoffset, refresh=False)
-                if c == ":":
-                    xoffset += 2  # colon is 1 pixels + a space
-                else:
-                    xoffset += 4  # digits are 3 pixels + a space
-
-        self.enclosure.mouth_display(img_code="CIAAAA", x=29,
-                                     refresh=False)
-        time.sleep(5)
-        self.enclosure.mouth_reset()
-        self.enclosure.activate_mouth_events()
+        self.bus.emit(Message("ovos.mk1.display_time",
+                             {"text": display_time}))
+        # self.enclosure.deactivate_mouth_events()
+        # # Map characters to the display encoding for a Mark 1
+        # # (4x8 except colon, which is 2x8)
+        # code_dict = {
+        #     ':': 'CIICAA',
+        #     '0': 'EIMHEEMHAA',
+        #     '1': 'EIIEMHAEAA',
+        #     '2': 'EIEHEFMFAA',
+        #     '3': 'EIEFEFMHAA',
+        #     '4': 'EIMBABMHAA',
+        #     '5': 'EIMFEFEHAA',
+        #     '6': 'EIMHEFEHAA',
+        #     '7': 'EIEAEAMHAA',
+        #     '8': 'EIMHEFMHAA',
+        #     '9': 'EIMBEBMHAA',
+        # }
+        # 
+        # # clear screen (draw two blank sections, numbers cover rest)
+        # if len(display_time) == 4:
+        #     # for 4-character times, 9x8 blank
+        #     self.enclosure.mouth_display(img_code="JIAAAAAAAAAAAAAAAAAA",
+        #                                  refresh=False)
+        #     self.enclosure.mouth_display(img_code="JIAAAAAAAAAAAAAAAAAA",
+        #                                  x=22, refresh=False)
+        # else:
+        #     # for 5-character times, 7x8 blank
+        #     self.enclosure.mouth_display(img_code="HIAAAAAAAAAAAAAA",
+        #                                  refresh=False)
+        #     self.enclosure.mouth_display(img_code="HIAAAAAAAAAAAAAA",
+        #                                  x=24, refresh=False)
+        # 
+        # # draw the time, centered on display
+        # xoffset = (32 - (4 * (len(display_time)) - 2)) / 2
+        # for c in display_time:
+        #     if c in code_dict:
+        #         self.enclosure.mouth_display(img_code=code_dict[c],
+        #                                      x=xoffset, refresh=False)
+        #         if c == ":":
+        #             xoffset += 2  # colon is 1 pixels + a space
+        #         else:
+        #             xoffset += 4  # digits are 3 pixels + a space
+        # 
+        # self.enclosure.mouth_display(img_code="CIAAAA", x=29,
+        #                              refresh=False)
+        # time.sleep(5)
+        # self.enclosure.mouth_reset()
+        # self.enclosure.activate_mouth_events()
 
     def show_time_gui(self, display_time):
         """ Display time on the GUI. """


### PR DESCRIPTION
Emits `ovos.mk1.display.time` and `ovos.mk1.display.date` to be used by ovos-PHAL-plugin-mk1.

Not a breaking change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logging capabilities for date and time information sent to the Mark 1 device.
  
- **Bug Fixes**
	- Improved the interaction with the Mark 1 by centralizing logging and message emission processes.

- **Refactor**
	- Updated methods to log actions instead of directly manipulating the display, promoting a more modular approach.

- **Chores**
	- Updated workflow configuration to exclude additional file patterns from build tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->