### PR TITLE
Add locale resources for location disambiguation and date phrasing

### DIFF
--- a/locale/en-us/ambiguous_locations.list
+++ b/locale/en-us/ambiguous_locations.list
@@ -1,0 +1,15 @@
+australia
+brazil
+canada
+indonesia
+mexico
+new zealand
+russia
+spain
+us
+usa
+the us
+the usa
+united states
+the united states
+the united states of america

--- a/locale/en-us/current_weekend_phrases.list
+++ b/locale/en-us/current_weekend_phrases.list
@@ -1,0 +1,1 @@
+this weekend

--- a/locale/en-us/non_location_phrases.list
+++ b/locale/en-us/non_location_phrases.list
@@ -1,0 +1,5 @@
+now
+right now
+the moment
+this moment
+the current moment

--- a/locale/fr-fr/ambiguous_locations.list
+++ b/locale/fr-fr/ambiguous_locations.list
@@ -1,0 +1,19 @@
+australie
+bresil
+brésil
+canada
+espagne
+indonesie
+indonésie
+mexique
+nouvelle-zelande
+nouvelle-zélande
+russie
+usa
+etats-unis
+états-unis
+les usa
+les etats-unis
+les états-unis
+les etats-unis d'amerique
+les états-unis d'amérique

--- a/locale/fr-fr/current_weekend_phrases.list
+++ b/locale/fr-fr/current_weekend_phrases.list
@@ -1,0 +1,3 @@
+ce week-end
+ce weekend
+ce week end

--- a/locale/fr-fr/non_location_phrases.list
+++ b/locale/fr-fr/non_location_phrases.list
@@ -1,0 +1,4 @@
+ce moment
+ce moment-ci
+ce moment la
+ce moment-là

--- a/locale/tr-tr/current_weekend_phrases.list
+++ b/locale/tr-tr/current_weekend_phrases.list
@@ -1,0 +1,1 @@
+bu hafta sonu


### PR DESCRIPTION
## Summary
- add locale list resources for ambiguous locations
- add locale list resources for false-positive non-location phrases
- add locale list resources to disambiguate current weekend wording

## Notes
This PR intentionally contains only locale resource files.

It depends on the runtime loader added in #185, which consumes these `.list` resources from `__init__.py`.

Expected merge order:
- merge #186 first or together with #185
- merge #185 before relying on these resources at runtime
