### PR TITLE
fix(deps): allow ovos-workshop 9.x (widen <9.0.0 -> <10.0.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ tzlocal>=5.3.1
 timezonefinder>=6.5.9
 geocoder~=1.38
 ovos-utils>=0.8.1
-ovos-workshop>=0.0.16,<9.0.0
+ovos-workshop>=0.0.16,<10.0.0
 ovos-date-parser>=0.0.1,<1.0.0
 ovos-utterance-normalizer>=0.0.1,<1.0.0


### PR DESCRIPTION
ovos-workshop is on the 9.x line. This `<9.0.0` cap is one of the last in core's `skills-essential` extra blocking `ovos-core` from resolving its modern `ovos-workshop>=9.x` floor (PIPELINE-1 / handler-lifecycle work). Widen to `<10.0.0`, matching the rest of the skill ecosystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)