### PR TITLE
fix: repair malformed intent templates across translations

### DIFF
--- a/locale/cs-CZ/intents/what.time.will.it.be.intent
+++ b/locale/cs-CZ/intents/what.time.will.it.be.intent
@@ -250,24 +250,24 @@ jaký je čas za {offset} sekundy
 jaký je čas za {offset} sekundy  v {location}
 jaký je čas za {offset} sekundy od teď
 jaký je čas za {offset} sekundy od teď v {location}
-jaký čas  v {location}  {offset} hodin
-jaký čas  v {location}  {offset} hodin od teď
-jaký čas  v {location}  {offset} hodinu
-jaký čas  v {location}  {offset} hodinu od teď
-jaký čas  v {location}  {offset} hodiny
-jaký čas  v {location}  {offset} hodiny od teď
-jaký čas  v {location}  {offset} minut
-jaký čas  v {location}  {offset} minut od teď
-jaký čas  v {location}  {offset} minutu
-jaký čas  v {location}  {offset} minutu od teď
-jaký čas  v {location}  {offset} minuty
-jaký čas  v {location}  {offset} minuty od teď
-jaký čas  v {location}  {offset} sekund
-jaký čas  v {location}  {offset} sekund od teď
-jaký čas  v {location}  {offset} sekundu
-jaký čas  v {location}  {offset} sekundu od teď
-jaký čas  v {location}  {offset} sekundy
-jaký čas  v {location}  {offset} sekundy od teď
+jaký čas  v {location} za {offset} hodin
+jaký čas  v {location} za {offset} hodin od teď
+jaký čas  v {location} za {offset} hodinu
+jaký čas  v {location} za {offset} hodinu od teď
+jaký čas  v {location} za {offset} hodiny
+jaký čas  v {location} za {offset} hodiny od teď
+jaký čas  v {location} za {offset} minut
+jaký čas  v {location} za {offset} minut od teď
+jaký čas  v {location} za {offset} minutu
+jaký čas  v {location} za {offset} minutu od teď
+jaký čas  v {location} za {offset} minuty
+jaký čas  v {location} za {offset} minuty od teď
+jaký čas  v {location} za {offset} sekund
+jaký čas  v {location} za {offset} sekund od teď
+jaký čas  v {location} za {offset} sekundu
+jaký čas  v {location} za {offset} sekundu od teď
+jaký čas  v {location} za {offset} sekundy
+jaký čas  v {location} za {offset} sekundy od teď
 jaký čas  v {location} za {offset} hodin
 jaký čas  v {location} za {offset} hodin od teď
 jaký čas  v {location} za {offset} hodinu
@@ -322,24 +322,24 @@ jaký čas bude  {offset} sekundy
 jaký čas bude  {offset} sekundy  v {location}
 jaký čas bude  {offset} sekundy od teď
 jaký čas bude  {offset} sekundy od teď v {location}
-jaký čas bude v {location}  {offset} hodin
-jaký čas bude v {location}  {offset} hodin od teď
-jaký čas bude v {location}  {offset} hodinu
-jaký čas bude v {location}  {offset} hodinu od teď
-jaký čas bude v {location}  {offset} hodiny
-jaký čas bude v {location}  {offset} hodiny od teď
-jaký čas bude v {location}  {offset} minut
-jaký čas bude v {location}  {offset} minut od teď
-jaký čas bude v {location}  {offset} minutu
-jaký čas bude v {location}  {offset} minutu od teď
-jaký čas bude v {location}  {offset} minuty
-jaký čas bude v {location}  {offset} minuty od teď
-jaký čas bude v {location}  {offset} sekund
-jaký čas bude v {location}  {offset} sekund od teď
-jaký čas bude v {location}  {offset} sekundu
-jaký čas bude v {location}  {offset} sekundu od teď
-jaký čas bude v {location}  {offset} sekundy
-jaký čas bude v {location}  {offset} sekundy od teď
+jaký čas bude v {location} za {offset} hodin
+jaký čas bude v {location} za {offset} hodin od teď
+jaký čas bude v {location} za {offset} hodinu
+jaký čas bude v {location} za {offset} hodinu od teď
+jaký čas bude v {location} za {offset} hodiny
+jaký čas bude v {location} za {offset} hodiny od teď
+jaký čas bude v {location} za {offset} minut
+jaký čas bude v {location} za {offset} minut od teď
+jaký čas bude v {location} za {offset} minutu
+jaký čas bude v {location} za {offset} minutu od teď
+jaký čas bude v {location} za {offset} minuty
+jaký čas bude v {location} za {offset} minuty od teď
+jaký čas bude v {location} za {offset} sekund
+jaký čas bude v {location} za {offset} sekund od teď
+jaký čas bude v {location} za {offset} sekundu
+jaký čas bude v {location} za {offset} sekundu od teď
+jaký čas bude v {location} za {offset} sekundy
+jaký čas bude v {location} za {offset} sekundy od teď
 jaký čas bude v {location} za {offset} hodin
 jaký čas bude v {location} za {offset} hodin od teď
 jaký čas bude v {location} za {offset} hodinu
@@ -412,24 +412,6 @@ kdy bude {offset} sekundu  v {location}
 kdy bude {offset} sekundu od teď v {location}
 kdy bude {offset} sekundy  v {location}
 kdy bude {offset} sekundy od teď v {location}
-kdy bude {offset} {offset} hodin
-kdy bude {offset} {offset} hodin od teď
-kdy bude {offset} {offset} hodinu
-kdy bude {offset} {offset} hodinu od teď
-kdy bude {offset} {offset} hodiny
-kdy bude {offset} {offset} hodiny od teď
-kdy bude {offset} {offset} minut
-kdy bude {offset} {offset} minut od teď
-kdy bude {offset} {offset} minutu
-kdy bude {offset} {offset} minutu od teď
-kdy bude {offset} {offset} minuty
-kdy bude {offset} {offset} minuty od teď
-kdy bude {offset} {offset} sekund
-kdy bude {offset} {offset} sekund od teď
-kdy bude {offset} {offset} sekundu
-kdy bude {offset} {offset} sekundu od teď
-kdy bude {offset} {offset} sekundy
-kdy bude {offset} {offset} sekundy od teď
 kdy je {offset} hodin  v {location}
 kdy je {offset} hodin od teď v {location}
 kdy je {offset} hodinu  v {location}
@@ -448,42 +430,6 @@ kdy je {offset} sekundu  v {location}
 kdy je {offset} sekundu od teď v {location}
 kdy je {offset} sekundy  v {location}
 kdy je {offset} sekundy od teď v {location}
-kdy je {offset} {offset} hodin
-kdy je {offset} {offset} hodin od teď
-kdy je {offset} {offset} hodinu
-kdy je {offset} {offset} hodinu od teď
-kdy je {offset} {offset} hodiny
-kdy je {offset} {offset} hodiny od teď
-kdy je {offset} {offset} minut
-kdy je {offset} {offset} minut od teď
-kdy je {offset} {offset} minutu
-kdy je {offset} {offset} minutu od teď
-kdy je {offset} {offset} minuty
-kdy je {offset} {offset} minuty od teď
-kdy je {offset} {offset} sekund
-kdy je {offset} {offset} sekund od teď
-kdy je {offset} {offset} sekundu
-kdy je {offset} {offset} sekundu od teď
-kdy je {offset} {offset} sekundy
-kdy je {offset} {offset} sekundy od teď
-kolik hodin  v {location}  {offset} hodin
-kolik hodin  v {location}  {offset} hodin od teď
-kolik hodin  v {location}  {offset} hodinu
-kolik hodin  v {location}  {offset} hodinu od teď
-kolik hodin  v {location}  {offset} hodiny
-kolik hodin  v {location}  {offset} hodiny od teď
-kolik hodin  v {location}  {offset} minut
-kolik hodin  v {location}  {offset} minut od teď
-kolik hodin  v {location}  {offset} minutu
-kolik hodin  v {location}  {offset} minutu od teď
-kolik hodin  v {location}  {offset} minuty
-kolik hodin  v {location}  {offset} minuty od teď
-kolik hodin  v {location}  {offset} sekund
-kolik hodin  v {location}  {offset} sekund od teď
-kolik hodin  v {location}  {offset} sekundu
-kolik hodin  v {location}  {offset} sekundu od teď
-kolik hodin  v {location}  {offset} sekundy
-kolik hodin  v {location}  {offset} sekundy od teď
 kolik hodin  v {location} za {offset} hodin
 kolik hodin  v {location} za {offset} hodin od teď
 kolik hodin  v {location} za {offset} hodinu
@@ -502,24 +448,42 @@ kolik hodin  v {location} za {offset} sekundu
 kolik hodin  v {location} za {offset} sekundu od teď
 kolik hodin  v {location} za {offset} sekundy
 kolik hodin  v {location} za {offset} sekundy od teď
-kolik hodin bude v {location}  {offset} hodin
-kolik hodin bude v {location}  {offset} hodin od teď
-kolik hodin bude v {location}  {offset} hodinu
-kolik hodin bude v {location}  {offset} hodinu od teď
-kolik hodin bude v {location}  {offset} hodiny
-kolik hodin bude v {location}  {offset} hodiny od teď
-kolik hodin bude v {location}  {offset} minut
-kolik hodin bude v {location}  {offset} minut od teď
-kolik hodin bude v {location}  {offset} minutu
-kolik hodin bude v {location}  {offset} minutu od teď
-kolik hodin bude v {location}  {offset} minuty
-kolik hodin bude v {location}  {offset} minuty od teď
-kolik hodin bude v {location}  {offset} sekund
-kolik hodin bude v {location}  {offset} sekund od teď
-kolik hodin bude v {location}  {offset} sekundu
-kolik hodin bude v {location}  {offset} sekundu od teď
-kolik hodin bude v {location}  {offset} sekundy
-kolik hodin bude v {location}  {offset} sekundy od teď
+kolik hodin  v {location} za {offset} hodin
+kolik hodin  v {location} za {offset} hodin od teď
+kolik hodin  v {location} za {offset} hodinu
+kolik hodin  v {location} za {offset} hodinu od teď
+kolik hodin  v {location} za {offset} hodiny
+kolik hodin  v {location} za {offset} hodiny od teď
+kolik hodin  v {location} za {offset} minut
+kolik hodin  v {location} za {offset} minut od teď
+kolik hodin  v {location} za {offset} minutu
+kolik hodin  v {location} za {offset} minutu od teď
+kolik hodin  v {location} za {offset} minuty
+kolik hodin  v {location} za {offset} minuty od teď
+kolik hodin  v {location} za {offset} sekund
+kolik hodin  v {location} za {offset} sekund od teď
+kolik hodin  v {location} za {offset} sekundu
+kolik hodin  v {location} za {offset} sekundu od teď
+kolik hodin  v {location} za {offset} sekundy
+kolik hodin  v {location} za {offset} sekundy od teď
+kolik hodin bude v {location} za {offset} hodin
+kolik hodin bude v {location} za {offset} hodin od teď
+kolik hodin bude v {location} za {offset} hodinu
+kolik hodin bude v {location} za {offset} hodinu od teď
+kolik hodin bude v {location} za {offset} hodiny
+kolik hodin bude v {location} za {offset} hodiny od teď
+kolik hodin bude v {location} za {offset} minut
+kolik hodin bude v {location} za {offset} minut od teď
+kolik hodin bude v {location} za {offset} minutu
+kolik hodin bude v {location} za {offset} minutu od teď
+kolik hodin bude v {location} za {offset} minuty
+kolik hodin bude v {location} za {offset} minuty od teď
+kolik hodin bude v {location} za {offset} sekund
+kolik hodin bude v {location} za {offset} sekund od teď
+kolik hodin bude v {location} za {offset} sekundu
+kolik hodin bude v {location} za {offset} sekundu od teď
+kolik hodin bude v {location} za {offset} sekundy
+kolik hodin bude v {location} za {offset} sekundy od teď
 kolik hodin bude v {location} za {offset} hodin
 kolik hodin bude v {location} za {offset} hodin od teď
 kolik hodin bude v {location} za {offset} hodinu

--- a/locale/da-DK/intents/current_date.intent
+++ b/locale/da-DK/intents/current_date.intent
@@ -7,10 +7,10 @@ Giv mig dagens komplette dato i {location}
 Hvad er den fulde dato i dag inklusive året
 Jeg har brug for at kende dato
 Jeg har brug for at kende dato i dag
-Jeg har brug for at kende dato i {lokation}
+Jeg har brug for at kende dato i {location}
 Jeg har brug for at kende kalenderdato
 Jeg har brug for at kende kalenderdato i dag
-Jeg har brug for at kende kalenderdato i {lokation}
+Jeg har brug for at kende kalenderdato i {location}
 Jeg vil gerne vide datoen
 Jeg vil gerne vide datoen i {location}
 Ved du, hvad datoen er

--- a/locale/da-DK/intents/time.until.intent
+++ b/locale/da-DK/intents/time.until.intent
@@ -1,42 +1,42 @@
-hvad tid er der tilbage før {dato}
-hvad tid er der tilbage indtil {dato}
-hvor lang er der tilbage før {dato}
-hvor lang er der tilbage indtil {dato}
-hvor lang har vi før {dato}
-hvor lang har vi indtil {dato}
+hvad tid er der tilbage før {date}
+hvad tid er der tilbage indtil {date}
+hvor lang er der tilbage før {date}
+hvor lang er der tilbage indtil {date}
+hvor lang har vi før {date}
+hvor lang har vi indtil {date}
 hvor lang tid fra nu er der {date}
-hvor langt fra er {dato}
-hvor langt fra er {dato} fra i dag
-hvor langt fra er {dato} fra nu
-hvor langt væk er {dato}
-hvor langt væk er {dato} fra i dag
-hvor langt væk er {dato} fra nu
+hvor langt fra er {date}
+hvor langt fra er {date} fra i dag
+hvor langt fra er {date} fra nu
+hvor langt væk er {date}
+hvor langt væk er {date} fra i dag
+hvor langt væk er {date} fra nu
 hvor længe siden var {date}
-hvor mange dage er der tilbage før {dato}
-hvor mange dage er der tilbage indtil {dato}
+hvor mange dage er der tilbage før {date}
+hvor mange dage er der tilbage indtil {date}
 hvor mange dage fra nu er der {date}
 hvor mange dage siden var {date}
-hvor mange timer er der tilbage før {dato}
-hvor mange timer er der tilbage indtil {dato}
-hvor mange uger er der tilbage før {dato}
-hvor mange uger er der tilbage indtil {dato}
-hvor meget længere er der tilbage før {dato}
-hvor meget længere er der tilbage indtil {dato}
-hvor meget længere har vi før {dato}
-hvor meget længere har vi indtil {dato}
-hvor meget tid er der tilbage før {dato}
-hvor meget tid er der tilbage indtil {dato}
-hvor meget tid har vi før {dato}
-hvor meget tid har vi indtil {dato}
-hvornår  er {dato}
-hvornår  vil det være {dato}
-hvornår er den forrige {dato}
-hvornår er den næste {dato}
-hvornår er den sidste {dato}
-hvornår er {dato}
-hvornår præcis er {dato}
-hvornår præcis vil det være {dato}
-hvornår var den forrige {dato}
-hvornår var den næste {dato}
-hvornår var den sidste {dato}
-hvornår var {dato}
+hvor mange timer er der tilbage før {date}
+hvor mange timer er der tilbage indtil {date}
+hvor mange uger er der tilbage før {date}
+hvor mange uger er der tilbage indtil {date}
+hvor meget længere er der tilbage før {date}
+hvor meget længere er der tilbage indtil {date}
+hvor meget længere har vi før {date}
+hvor meget længere har vi indtil {date}
+hvor meget tid er der tilbage før {date}
+hvor meget tid er der tilbage indtil {date}
+hvor meget tid har vi før {date}
+hvor meget tid har vi indtil {date}
+hvornår  er {date}
+hvornår  vil det være {date}
+hvornår er den forrige {date}
+hvornår er den næste {date}
+hvornår er den sidste {date}
+hvornår er {date}
+hvornår præcis er {date}
+hvornår præcis vil det være {date}
+hvornår var den forrige {date}
+hvornår var den næste {date}
+hvornår var den sidste {date}
+hvornår var {date}

--- a/locale/da-DK/intents/weekday.for.date.intent
+++ b/locale/da-DK/intents/weekday.for.date.intent
@@ -1,122 +1,122 @@
 Hvad er ugedag for {date}
-Jeg vil gerne vide hvad dag {dato} er
-Jeg vil gerne vide hvad dag {dato} var
-Jeg vil gerne vide hvad hverdag {dato} er
-Jeg vil gerne vide hvad hverdag {dato} var
-Jeg vil gerne vide hvad ugedag {dato} er
-Jeg vil gerne vide hvad ugedag {dato} var
-Jeg vil gerne vide hvilken dag {dato} er
-Jeg vil gerne vide hvilken dag {dato} var
-Jeg vil gerne vide hvilken hverdag {dato} er
-Jeg vil gerne vide hvilken hverdag {dato} var
-Jeg vil gerne vide hvilken ugedag {dato} er
-Jeg vil gerne vide hvilken ugedag {dato} var
-er {dato}  en fredag
-er {dato}  en lørdag
-er {dato}  en mandag
-er {dato}  en onsdag
-er {dato}  en søndag
-er {dato}  en tirsdag
-er {dato}  en torsdag
-er {dato} på en fredag
-er {dato} på en lørdag
-er {dato} på en mandag
-er {dato} på en onsdag
-er {dato} på en søndag
-er {dato} på en tirsdag
-er {dato} på en torsdag
-fortælle mig hvilken dag {dato} er
-fortælle mig hvilken dag {dato} var
-fortælle mig hvilken hverdag {dato} er
-fortælle mig hvilken hverdag {dato} var
-fortælle mig hvilken ugedag {dato} er
-fortælle mig hvilken ugedag {dato} var
-fortælle mig ugedagen for {dato}
-hvad dag er {dato}
-hvad dag var {dato}
-hvad dag vil det være på {dato}
-hvad dag {dato} er
-hvad dag {dato} var
-hvad hverdag er {dato}
-hvad hverdag var {dato}
-hvad hverdag vil det være på {dato}
-hvad hverdag {dato} er
-hvad hverdag {dato} var
-hvad ugedag er {dato}
-hvad ugedag var {dato}
-hvad ugedag vil det være på {dato}
-hvad ugedag {dato} er
-hvad ugedag {dato} var
-hvilken dag er {dato}
-hvilken dag falder {dato} på
-hvilken dag i ugen falder {dato} på
-hvilken dag var {dato}
-hvilken dag vil det være på {dato}
-hvilken dag {dato} er
-hvilken dag {dato} var
-hvilken hverdag er {dato}
-hvilken hverdag falder {dato} på
-hvilken hverdag var {dato}
-hvilken hverdag vil det være på {dato}
-hvilken hverdag {dato} er
-hvilken hverdag {dato} var
-hvilken ugedag er {dato}
-hvilken ugedag var {dato}
-hvilken ugedag vil det være på {dato}
-hvilken ugedag {dato} er
-hvilken ugedag {dato} var
-kan du fortælle mig hvilken dag {dato} er
-kan du fortælle mig hvilken dag {dato} var
-kan du fortælle mig hvilken hverdag {dato} er
-kan du fortælle mig hvilken hverdag {dato} var
-kan du fortælle mig hvilken ugedag {dato} er
-kan du fortælle mig hvilken ugedag {dato} var
-kan du fortælle mig ugedagen for {dato}
-på hvad dag er {dato}
-på hvad dag var {dato}
-på hvad dag vil det være på {dato}
-på hvad hverdag er {dato}
-på hvad hverdag var {dato}
-på hvad hverdag vil det være på {dato}
-på hvad ugedag er {dato}
-på hvad ugedag var {dato}
-på hvad ugedag vil det være på {dato}
-på hvilken dag er {dato}
-på hvilken dag falder {dato} på
-på hvilken dag i ugen falder {dato} på
-på hvilken dag var {dato}
-på hvilken dag vil det være på {dato}
-på hvilken hverdag er {dato}
-på hvilken hverdag falder {dato} på
-på hvilken hverdag var {dato}
-på hvilken hverdag vil det være på {dato}
-på hvilken ugedag er {dato}
-på hvilken ugedag var {dato}
-på hvilken ugedag vil det være på {dato}
-var {dato}  en fredag
-var {dato}  en lørdag
-var {dato}  en mandag
-var {dato}  en onsdag
-var {dato}  en søndag
-var {dato}  en tirsdag
-var {dato}  en torsdag
-var {dato} på en fredag
-var {dato} på en lørdag
-var {dato} på en mandag
-var {dato} på en onsdag
-var {dato} på en søndag
-var {dato} på en tirsdag
-var {dato} på en torsdag
-ved du ugedagen for {dato}
-ved du vide hvad dag {dato} er
-ved du vide hvad dag {dato} var
-ved du vide hvad hverdag {dato} er
-ved du vide hvad hverdag {dato} var
-ved du vide hvad ugedag {dato} er
-ved du vide hvad ugedag {dato} var
-ved du vide hvilken dag {dato} er
-ved du vide hvilken dag {dato} var
-ved du vide hvilken hverdag {dato} er
-ved du vide hvilken hverdag {dato} var
-ved du vide hvilken ugedag {dato} er
-ved du vide hvilken ugedag {dato} var
+Jeg vil gerne vide hvad dag {date} er
+Jeg vil gerne vide hvad dag {date} var
+Jeg vil gerne vide hvad hverdag {date} er
+Jeg vil gerne vide hvad hverdag {date} var
+Jeg vil gerne vide hvad ugedag {date} er
+Jeg vil gerne vide hvad ugedag {date} var
+Jeg vil gerne vide hvilken dag {date} er
+Jeg vil gerne vide hvilken dag {date} var
+Jeg vil gerne vide hvilken hverdag {date} er
+Jeg vil gerne vide hvilken hverdag {date} var
+Jeg vil gerne vide hvilken ugedag {date} er
+Jeg vil gerne vide hvilken ugedag {date} var
+er {date}  en fredag
+er {date}  en lørdag
+er {date}  en mandag
+er {date}  en onsdag
+er {date}  en søndag
+er {date}  en tirsdag
+er {date}  en torsdag
+er {date} på en fredag
+er {date} på en lørdag
+er {date} på en mandag
+er {date} på en onsdag
+er {date} på en søndag
+er {date} på en tirsdag
+er {date} på en torsdag
+fortælle mig hvilken dag {date} er
+fortælle mig hvilken dag {date} var
+fortælle mig hvilken hverdag {date} er
+fortælle mig hvilken hverdag {date} var
+fortælle mig hvilken ugedag {date} er
+fortælle mig hvilken ugedag {date} var
+fortælle mig ugedagen for {date}
+hvad dag er {date}
+hvad dag var {date}
+hvad dag vil det være på {date}
+hvad dag {date} er
+hvad dag {date} var
+hvad hverdag er {date}
+hvad hverdag var {date}
+hvad hverdag vil det være på {date}
+hvad hverdag {date} er
+hvad hverdag {date} var
+hvad ugedag er {date}
+hvad ugedag var {date}
+hvad ugedag vil det være på {date}
+hvad ugedag {date} er
+hvad ugedag {date} var
+hvilken dag er {date}
+hvilken dag falder {date} på
+hvilken dag i ugen falder {date} på
+hvilken dag var {date}
+hvilken dag vil det være på {date}
+hvilken dag {date} er
+hvilken dag {date} var
+hvilken hverdag er {date}
+hvilken hverdag falder {date} på
+hvilken hverdag var {date}
+hvilken hverdag vil det være på {date}
+hvilken hverdag {date} er
+hvilken hverdag {date} var
+hvilken ugedag er {date}
+hvilken ugedag var {date}
+hvilken ugedag vil det være på {date}
+hvilken ugedag {date} er
+hvilken ugedag {date} var
+kan du fortælle mig hvilken dag {date} er
+kan du fortælle mig hvilken dag {date} var
+kan du fortælle mig hvilken hverdag {date} er
+kan du fortælle mig hvilken hverdag {date} var
+kan du fortælle mig hvilken ugedag {date} er
+kan du fortælle mig hvilken ugedag {date} var
+kan du fortælle mig ugedagen for {date}
+på hvad dag er {date}
+på hvad dag var {date}
+på hvad dag vil det være på {date}
+på hvad hverdag er {date}
+på hvad hverdag var {date}
+på hvad hverdag vil det være på {date}
+på hvad ugedag er {date}
+på hvad ugedag var {date}
+på hvad ugedag vil det være på {date}
+på hvilken dag er {date}
+på hvilken dag falder {date} på
+på hvilken dag i ugen falder {date} på
+på hvilken dag var {date}
+på hvilken dag vil det være på {date}
+på hvilken hverdag er {date}
+på hvilken hverdag falder {date} på
+på hvilken hverdag var {date}
+på hvilken hverdag vil det være på {date}
+på hvilken ugedag er {date}
+på hvilken ugedag var {date}
+på hvilken ugedag vil det være på {date}
+var {date}  en fredag
+var {date}  en lørdag
+var {date}  en mandag
+var {date}  en onsdag
+var {date}  en søndag
+var {date}  en tirsdag
+var {date}  en torsdag
+var {date} på en fredag
+var {date} på en lørdag
+var {date} på en mandag
+var {date} på en onsdag
+var {date} på en søndag
+var {date} på en tirsdag
+var {date} på en torsdag
+ved du ugedagen for {date}
+ved du vide hvad dag {date} er
+ved du vide hvad dag {date} var
+ved du vide hvad hverdag {date} er
+ved du vide hvad hverdag {date} var
+ved du vide hvad ugedag {date} er
+ved du vide hvad ugedag {date} var
+ved du vide hvilken dag {date} er
+ved du vide hvilken dag {date} var
+ved du vide hvilken hverdag {date} er
+ved du vide hvilken hverdag {date} var
+ved du vide hvilken ugedag {date} er
+ved du vide hvilken ugedag {date} var

--- a/locale/da-DK/intents/what.day.is.it.intent
+++ b/locale/da-DK/intents/what.day.is.it.intent
@@ -9,18 +9,18 @@ fortæl mig den aktuelle dag i kalenderen i {location}
 fortæl mig den aktuelle dag i måneden
 fortæl mig den aktuelle dag i måneden i {location}
 hvilken dag  er det i dag
-hvilken dag  er det i {lokation}
+hvilken dag  er det i {location}
 hvilken dag  er i dag
 hvilken dag  er i {location}
 hvilken dag er det
 hvilken dag er i dag
 hvilken dag i kalenderen er det
 hvilken dag i kalenderen er det i dag
-hvilken dag i kalenderen er det i {lokation}
+hvilken dag i kalenderen er det i {location}
 hvilken dag i kalenderen er i dag
 hvilken dag i kalenderen er i {location}
 hvilken dag i måneden er det
 hvilken dag i måneden er det i dag
-hvilken dag i måneden er det i {lokation}
+hvilken dag i måneden er det i {location}
 hvilken dag i måneden er i dag
 hvilken dag i måneden er i {location}

--- a/locale/de-DE/intents/current_date.intent
+++ b/locale/de-DE/intents/current_date.intent
@@ -1,9 +1,9 @@
 Ich muss das Datum  wissen.
 Ich muss das Datum heute wissen.
-Ich muss das Datum in {Ort} wissen.
+Ich muss das Datum in {location} wissen.
 Ich muss das Kalenderdatum  wissen.
 Ich muss das Kalenderdatum heute wissen.
-Ich muss das Kalenderdatum in {Ort} wissen.
+Ich muss das Kalenderdatum in {location} wissen.
 Ich möchte das Datum  wissen
 Ich möchte das Datum in {location} wissen
 gib mir  das  Kalenderdatum

--- a/locale/de-DE/intents/time.until.intent
+++ b/locale/de-DE/intents/time.until.intent
@@ -1,47 +1,47 @@
 in wie vielen Tagen ist {date}
-wann  ist {Datum}
-wann  wird es sein {Datum}
-wann genau ist {Datum}
-wann genau wird es sein {Datum}
-wann ist das letzte {Datum}
-wann ist das nächste {Datum}
-wann ist das vorherige {Datum}
-wann ist {Datum}
-wann war das letzte {Datum}
-wann war das nächste {Datum}
-wann war das vorherige {Datum}
-wann war {Datum}
-wie lange bleibt bis {Datum}
-wie lange bleibt vor {Datum}
-wie lange haben wir bis {Datum}
-wie lange haben wir vor {Datum}
+wann  ist {date}
+wann  wird es sein {date}
+wann genau ist {date}
+wann genau wird es sein {date}
+wann ist das letzte {date}
+wann ist das nächste {date}
+wann ist das vorherige {date}
+wann ist {date}
+wann war das letzte {date}
+wann war das nächste {date}
+wann war das vorherige {date}
+wann war {date}
+wie lange bleibt bis {date}
+wie lange bleibt vor {date}
+wie lange haben wir bis {date}
+wie lange haben wir vor {date}
 wie lange ist es bis {date}
 wie lange ist {date} her
-wie viel Zeit  bleibt  bis {Datum}
-wie viel Zeit  bleibt vor  {Datum}
-wie viel Zeit bleibt   bis {Datum}
-wie viel Zeit bleibt  vor  {Datum}
-wie viel Zeit bleibt bis {Datum}
-wie viel Zeit bleibt vor {Datum}
-wie viel Zeit haben wir bis {Datum}
-wie viel Zeit haben wir vor {Datum}
-wie viel länger bleibt bis {Datum}
-wie viel länger bleibt vor {Datum}
-wie viel länger haben wir bis {Datum}
-wie viel länger haben wir vor {Datum}
-wie viele Stunden  verbleibend bis {Datum}
-wie viele Stunden  verbleibend vor {Datum}
-wie viele Stunden sind noch  bis {Datum}
-wie viele Stunden sind noch  vor {Datum}
-wie viele Tage  verbleibend bis {Datum}
-wie viele Tage  verbleibend vor {Datum}
+wie viel Zeit  bleibt  bis {date}
+wie viel Zeit  bleibt vor  {date}
+wie viel Zeit bleibt   bis {date}
+wie viel Zeit bleibt  vor  {date}
+wie viel Zeit bleibt bis {date}
+wie viel Zeit bleibt vor {date}
+wie viel Zeit haben wir bis {date}
+wie viel Zeit haben wir vor {date}
+wie viel länger bleibt bis {date}
+wie viel länger bleibt vor {date}
+wie viel länger haben wir bis {date}
+wie viel länger haben wir vor {date}
+wie viele Stunden  verbleibend bis {date}
+wie viele Stunden  verbleibend vor {date}
+wie viele Stunden sind noch  bis {date}
+wie viele Stunden sind noch  vor {date}
+wie viele Tage  verbleibend bis {date}
+wie viele Tage  verbleibend vor {date}
 wie viele Tage ist {date} her
-wie viele Tage sind noch  bis {Datum}
-wie viele Tage sind noch  vor {Datum}
-wie viele Wochen  verbleibend bis {Datum}
-wie viele Wochen  verbleibend vor {Datum}
-wie viele Wochen sind noch  bis {Datum}
-wie viele Wochen sind noch  vor {Datum}
+wie viele Tage sind noch  bis {date}
+wie viele Tage sind noch  vor {date}
+wie viele Wochen  verbleibend bis {date}
+wie viele Wochen  verbleibend vor {date}
+wie viele Wochen sind noch  bis {date}
+wie viele Wochen sind noch  vor {date}
 wie weit ab ist {date}
 wie weit ab ist {date} von heute
 wie weit ab ist {date} von jetzt

--- a/locale/de-DE/intents/weekday.for.date.intent
+++ b/locale/de-DE/intents/weekday.for.date.intent
@@ -1,23 +1,23 @@
-Ich möchte was Tag {Datum} ist
-Ich möchte was Tag {Datum} war
-Ich möchte was Wochentag {Datum} ist
-Ich möchte was Wochentag {Datum} war
-Ich möchte welcher Tag {Datum} ist
-Ich möchte welcher Tag {Datum} war
-Ich möchte welcher Wochentag {Datum} ist
-Ich möchte welcher Wochentag {Datum} war
-an was Tag ist {Datum}
-an was Tag war {Datum}
-an was Tag wird es sein an {Datum}
-an was Wochentag ist {Datum}
-an was Wochentag war {Datum}
-an was Wochentag wird es sein an {Datum}
-an welchem Tag ist {Datum}
-an welchem Tag war {Datum}
-an welchem Tag wird es sein an {Datum}
-an welchem Wochentag ist {Datum}
-an welchem Wochentag war {Datum}
-an welchem Wochentag wird es sein an {Datum}
+Ich möchte was Tag {date} ist
+Ich möchte was Tag {date} war
+Ich möchte was Wochentag {date} ist
+Ich möchte was Wochentag {date} war
+Ich möchte welcher Tag {date} ist
+Ich möchte welcher Tag {date} war
+Ich möchte welcher Wochentag {date} ist
+Ich möchte welcher Wochentag {date} war
+an was Tag ist {date}
+an was Tag war {date}
+an was Tag wird es sein an {date}
+an was Wochentag ist {date}
+an was Wochentag war {date}
+an was Wochentag wird es sein an {date}
+an welchem Tag ist {date}
+an welchem Tag war {date}
+an welchem Tag wird es sein an {date}
+an welchem Wochentag ist {date}
+an welchem Wochentag war {date}
+an welchem Wochentag wird es sein an {date}
 auf welchen Tag fällt der{date}
 auf welchen Tag fällt {date}
 auf welchen Wochentag fällt der{date}
@@ -37,15 +37,15 @@ ist {date} an einem Montag
 ist {date} an einem Samstag
 ist {date} an einem Sonntag
 kannst du mir sagen den Wochentag für {date}
-kannst du mir sagen, welcher Tag {Datum} ist
-kannst du mir sagen, welcher Tag {Datum} war
-kannst du mir sagen, welcher Wochentag {Datum} ist
-kannst du mir sagen, welcher Wochentag {Datum} war
+kannst du mir sagen, welcher Tag {date} ist
+kannst du mir sagen, welcher Tag {date} war
+kannst du mir sagen, welcher Wochentag {date} ist
+kannst du mir sagen, welcher Wochentag {date} war
 mir sagen den Wochentag für {date}
-mir sagen, welcher Tag {Datum} ist
-mir sagen, welcher Tag {Datum} war
-mir sagen, welcher Wochentag {Datum} ist
-mir sagen, welcher Wochentag {Datum} war
+mir sagen, welcher Tag {date} ist
+mir sagen, welcher Tag {date} war
+mir sagen, welcher Wochentag {date} ist
+mir sagen, welcher Wochentag {date} war
 war {date}  einem Dienstag
 war {date}  einem Donnerstag
 war {date}  einem Freitag
@@ -60,39 +60,39 @@ war {date} an einem Mittwoch
 war {date} an einem Montag
 war {date} an einem Samstag
 war {date} an einem Sonntag
-was Tag ist {Datum}
-was Tag war {Datum}
-was Tag wird es sein an {Datum}
-was Tag {Datum} ist
-was Tag {Datum} war
-was Wochentag ist {Datum}
-was Wochentag war {Datum}
-was Wochentag wird es sein an {Datum}
-was Wochentag {Datum} ist
-was Wochentag {Datum} war
+was Tag ist {date}
+was Tag war {date}
+was Tag wird es sein an {date}
+was Tag {date} ist
+was Tag {date} war
+was Wochentag ist {date}
+was Wochentag war {date}
+was Wochentag wird es sein an {date}
+was Wochentag {date} ist
+was Wochentag {date} war
 was ist der Wochentag für {date}
 weißt du den Wochentag für {date}
-weißt du was Tag {Datum} ist
-weißt du was Tag {Datum} war
-weißt du was Wochentag {Datum} ist
-weißt du was Wochentag {Datum} war
-weißt du welcher Tag {Datum} ist
-weißt du welcher Tag {Datum} war
-weißt du welcher Wochentag {Datum} ist
-weißt du welcher Wochentag {Datum} war
-welchem Tag ist {Datum}
-welchem Tag war {Datum}
-welchem Tag wird es sein an {Datum}
-welchem Wochentag ist {Datum}
-welchem Wochentag war {Datum}
-welchem Wochentag wird es sein an {Datum}
+weißt du was Tag {date} ist
+weißt du was Tag {date} war
+weißt du was Wochentag {date} ist
+weißt du was Wochentag {date} war
+weißt du welcher Tag {date} ist
+weißt du welcher Tag {date} war
+weißt du welcher Wochentag {date} ist
+weißt du welcher Wochentag {date} war
+welchem Tag ist {date}
+welchem Tag war {date}
+welchem Tag wird es sein an {date}
+welchem Wochentag ist {date}
+welchem Wochentag war {date}
+welchem Wochentag wird es sein an {date}
 welchen Tag fällt der{date}
 welchen Tag fällt {date}
 welchen Wochentag fällt der{date}
 welchen Wochentag fällt {date}
-welcher Tag {Datum} ist
-welcher Tag {Datum} war
-welcher Wochentag ist {Datum}
-welcher Wochentag war {Datum}
-welcher Wochentag {Datum} ist
-welcher Wochentag {Datum} war
+welcher Tag {date} ist
+welcher Tag {date} war
+welcher Wochentag ist {date}
+welcher Wochentag war {date}
+welcher Wochentag {date} ist
+welcher Wochentag {date} war

--- a/locale/de-DE/intents/what.day.is.it.intent
+++ b/locale/de-DE/intents/what.day.is.it.intent
@@ -15,7 +15,7 @@ was ist der Tag des Monats heute
 was ist der Tag des Monats in {location}
 welcher Tag  ist es
 welcher Tag  ist es heute
-welcher Tag  ist es in {Ort}
+welcher Tag  ist es in {location}
 welcher Tag  ist heute
 welcher Tag  ist heute
 Was für ein Tag ist heute
@@ -27,7 +27,7 @@ welcher Tag  ist in {location}
 Was für ein Tag ist in {location}
 welcher Tag des Kalenders ist es
 welcher Tag des Kalenders ist es heute
-welcher Tag des Kalenders ist es in {Ort}
+welcher Tag des Kalenders ist es in {location}
 welcher Tag des Kalenders ist heute
 welcher Tag des Kalenders ist heute
 Was für ein Tag ist heute
@@ -39,7 +39,7 @@ welcher Tag des Kalenders ist in {location}
 Was für ein Tag ist in {location}
 welcher Tag des Monats ist es
 welcher Tag des Monats ist es heute
-welcher Tag des Monats ist es in {Ort}
+welcher Tag des Monats ist es in {location}
 welcher Tag des Monats ist heute
 welcher Tag des Monats ist heute
 Was für ein Tag ist heute

--- a/locale/de-DE/intents/what.time.will.it.be.intent
+++ b/locale/de-DE/intents/what.time.will.it.be.intent
@@ -1,51 +1,51 @@
-Wann ist es, wenn  Ich verbringe {Offset}  Minute
-Wann ist es, wenn  Ich verbringe {Offset}  Minute  in {location}
-Wann ist es, wenn  Ich verbringe {Offset}  Minuten
-Wann ist es, wenn  Ich verbringe {Offset}  Minuten  in {location}
-Wann ist es, wenn  Ich verbringe {Offset}  Stunde
-Wann ist es, wenn  Ich verbringe {Offset}  Stunde in {location}
-Wann ist es, wenn  Ich verbringe {Offset}  Stunden
-Wann ist es, wenn  Ich verbringe {Offset}  Stunden in {location}
-Wann ist es, wenn  Ich verbringe {Offset} Sekunde
-Wann ist es, wenn  Ich verbringe {Offset} Sekunde  in {location}
-Wann ist es, wenn  Ich verbringe {Offset} Sekunden
-Wann ist es, wenn  Ich verbringe {Offset} Sekunden  in {location}
-Wann ist es, wenn ich warte  {Offset}  Minute
-Wann ist es, wenn ich warte  {Offset}  Minute  in {location}
-Wann ist es, wenn ich warte  {Offset}  Minuten
-Wann ist es, wenn ich warte  {Offset}  Minuten  in {location}
-Wann ist es, wenn ich warte  {Offset}  Stunde
-Wann ist es, wenn ich warte  {Offset}  Stunde in {location}
-Wann ist es, wenn ich warte  {Offset}  Stunden
-Wann ist es, wenn ich warte  {Offset}  Stunden in {location}
-Wann ist es, wenn ich warte  {Offset} Sekunde
-Wann ist es, wenn ich warte  {Offset} Sekunde  in {location}
-Wann ist es, wenn ich warte  {Offset} Sekunden
-Wann ist es, wenn ich warte  {Offset} Sekunden  in {location}
-Wie spät ist es  ist es, wenn  Ich verbringe {Offset}  Minute
-Wie spät ist es  ist es, wenn  Ich verbringe {Offset}  Minute  in {location}
-Wie spät ist es  ist es, wenn  Ich verbringe {Offset}  Minuten
-Wie spät ist es  ist es, wenn  Ich verbringe {Offset}  Minuten  in {location}
-Wie spät ist es  ist es, wenn  Ich verbringe {Offset}  Stunde
-Wie spät ist es  ist es, wenn  Ich verbringe {Offset}  Stunde in {location}
-Wie spät ist es  ist es, wenn  Ich verbringe {Offset}  Stunden
-Wie spät ist es  ist es, wenn  Ich verbringe {Offset}  Stunden in {location}
-Wie spät ist es  ist es, wenn  Ich verbringe {Offset} Sekunde
-Wie spät ist es  ist es, wenn  Ich verbringe {Offset} Sekunde  in {location}
-Wie spät ist es  ist es, wenn  Ich verbringe {Offset} Sekunden
-Wie spät ist es  ist es, wenn  Ich verbringe {Offset} Sekunden  in {location}
-Wie spät ist es  ist es, wenn ich warte  {Offset}  Minute
-Wie spät ist es  ist es, wenn ich warte  {Offset}  Minute  in {location}
-Wie spät ist es  ist es, wenn ich warte  {Offset}  Minuten
-Wie spät ist es  ist es, wenn ich warte  {Offset}  Minuten  in {location}
-Wie spät ist es  ist es, wenn ich warte  {Offset}  Stunde
-Wie spät ist es  ist es, wenn ich warte  {Offset}  Stunde in {location}
-Wie spät ist es  ist es, wenn ich warte  {Offset}  Stunden
-Wie spät ist es  ist es, wenn ich warte  {Offset}  Stunden in {location}
-Wie spät ist es  ist es, wenn ich warte  {Offset} Sekunde
-Wie spät ist es  ist es, wenn ich warte  {Offset} Sekunde  in {location}
-Wie spät ist es  ist es, wenn ich warte  {Offset} Sekunden
-Wie spät ist es  ist es, wenn ich warte  {Offset} Sekunden  in {location}
+Wann ist es, wenn  Ich verbringe {offset}  Minute
+Wann ist es, wenn  Ich verbringe {offset}  Minute  in {location}
+Wann ist es, wenn  Ich verbringe {offset}  Minuten
+Wann ist es, wenn  Ich verbringe {offset}  Minuten  in {location}
+Wann ist es, wenn  Ich verbringe {offset}  Stunde
+Wann ist es, wenn  Ich verbringe {offset}  Stunde in {location}
+Wann ist es, wenn  Ich verbringe {offset}  Stunden
+Wann ist es, wenn  Ich verbringe {offset}  Stunden in {location}
+Wann ist es, wenn  Ich verbringe {offset} Sekunde
+Wann ist es, wenn  Ich verbringe {offset} Sekunde  in {location}
+Wann ist es, wenn  Ich verbringe {offset} Sekunden
+Wann ist es, wenn  Ich verbringe {offset} Sekunden  in {location}
+Wann ist es, wenn ich warte  {offset}  Minute
+Wann ist es, wenn ich warte  {offset}  Minute  in {location}
+Wann ist es, wenn ich warte  {offset}  Minuten
+Wann ist es, wenn ich warte  {offset}  Minuten  in {location}
+Wann ist es, wenn ich warte  {offset}  Stunde
+Wann ist es, wenn ich warte  {offset}  Stunde in {location}
+Wann ist es, wenn ich warte  {offset}  Stunden
+Wann ist es, wenn ich warte  {offset}  Stunden in {location}
+Wann ist es, wenn ich warte  {offset} Sekunde
+Wann ist es, wenn ich warte  {offset} Sekunde  in {location}
+Wann ist es, wenn ich warte  {offset} Sekunden
+Wann ist es, wenn ich warte  {offset} Sekunden  in {location}
+Wie spät ist es  ist es, wenn  Ich verbringe {offset}  Minute
+Wie spät ist es  ist es, wenn  Ich verbringe {offset}  Minute  in {location}
+Wie spät ist es  ist es, wenn  Ich verbringe {offset}  Minuten
+Wie spät ist es  ist es, wenn  Ich verbringe {offset}  Minuten  in {location}
+Wie spät ist es  ist es, wenn  Ich verbringe {offset}  Stunde
+Wie spät ist es  ist es, wenn  Ich verbringe {offset}  Stunde in {location}
+Wie spät ist es  ist es, wenn  Ich verbringe {offset}  Stunden
+Wie spät ist es  ist es, wenn  Ich verbringe {offset}  Stunden in {location}
+Wie spät ist es  ist es, wenn  Ich verbringe {offset} Sekunde
+Wie spät ist es  ist es, wenn  Ich verbringe {offset} Sekunde  in {location}
+Wie spät ist es  ist es, wenn  Ich verbringe {offset} Sekunden
+Wie spät ist es  ist es, wenn  Ich verbringe {offset} Sekunden  in {location}
+Wie spät ist es  ist es, wenn ich warte  {offset}  Minute
+Wie spät ist es  ist es, wenn ich warte  {offset}  Minute  in {location}
+Wie spät ist es  ist es, wenn ich warte  {offset}  Minuten
+Wie spät ist es  ist es, wenn ich warte  {offset}  Minuten  in {location}
+Wie spät ist es  ist es, wenn ich warte  {offset}  Stunde
+Wie spät ist es  ist es, wenn ich warte  {offset}  Stunde in {location}
+Wie spät ist es  ist es, wenn ich warte  {offset}  Stunden
+Wie spät ist es  ist es, wenn ich warte  {offset}  Stunden in {location}
+Wie spät ist es  ist es, wenn ich warte  {offset} Sekunde
+Wie spät ist es  ist es, wenn ich warte  {offset} Sekunde  in {location}
+Wie spät ist es  ist es, wenn ich warte  {offset} Sekunden
+Wie spät ist es  ist es, wenn ich warte  {offset} Sekunden  in {location}
 in {offset} Minute  wie spät wird es  sein
 in {offset} Minute  wie spät wird es  werden
 in {offset} Minute  wie spät wird es in {location} sein
@@ -94,339 +94,339 @@ in {offset} Stunden ab jetzt wie spät wird es  sein
 in {offset} Stunden ab jetzt wie spät wird es  werden
 in {offset} Stunden ab jetzt wie spät wird es in {location} sein
 in {offset} Stunden ab jetzt wie spät wird es in {location} werden
-um wie viel Uhr ist es {Offset} Minuten
-um wie viel Uhr ist es {Offset} Minuten  in {location}
-um wie viel Uhr ist es {Offset} Minuten ab jetzt
-um wie viel Uhr ist es {Offset} Minuten ab jetzt in {location}
-um wie viel Uhr ist es {Offset} Sekunden
-um wie viel Uhr ist es {Offset} Sekunden  in {location}
-um wie viel Uhr ist es {Offset} Sekunden ab jetzt
-um wie viel Uhr ist es {Offset} Sekunden ab jetzt in {location}
-um wie viel Uhr ist es {Offset} Stunden
-um wie viel Uhr ist es {Offset} Stunden  in {location}
-um wie viel Uhr ist es {Offset} Stunden ab jetzt
-um wie viel Uhr ist es {Offset} Stunden ab jetzt in {location}
-um wie viel Uhr wird es sein {Offset} Minuten
-um wie viel Uhr wird es sein {Offset} Minuten  in {location}
-um wie viel Uhr wird es sein {Offset} Minuten ab jetzt
-um wie viel Uhr wird es sein {Offset} Minuten ab jetzt in {location}
-um wie viel Uhr wird es sein {Offset} Sekunden
-um wie viel Uhr wird es sein {Offset} Sekunden  in {location}
-um wie viel Uhr wird es sein {Offset} Sekunden ab jetzt
-um wie viel Uhr wird es sein {Offset} Sekunden ab jetzt in {location}
-um wie viel Uhr wird es sein {Offset} Stunden
-um wie viel Uhr wird es sein {Offset} Stunden  in {location}
-um wie viel Uhr wird es sein {Offset} Stunden ab jetzt
-um wie viel Uhr wird es sein {Offset} Stunden ab jetzt in {location}
-wann Zeit wird es sein in {Offset} Minute
-wann Zeit wird es sein in {Offset} Minute in {location}
-wann Zeit wird es sein in {Offset} Minuten
-wann Zeit wird es sein in {Offset} Minuten in {location}
-wann Zeit wird es sein in {Offset} Sekunde
-wann Zeit wird es sein in {Offset} Sekunde in {location}
-wann Zeit wird es sein in {Offset} Sekunden
-wann Zeit wird es sein in {Offset} Sekunden in {location}
-wann Zeit wird es sein in {Offset} Stunde
-wann Zeit wird es sein in {Offset} Stunde in {location}
-wann Zeit wird es sein in {Offset} Stunden
-wann Zeit wird es sein in {Offset} Stunden in {location}
-wann Zeit wird es sein nach {Offset} Minute
-wann Zeit wird es sein nach {Offset} Minute in {location}
-wann Zeit wird es sein nach {Offset} Minuten
-wann Zeit wird es sein nach {Offset} Minuten in {location}
-wann Zeit wird es sein nach {Offset} Sekunde
-wann Zeit wird es sein nach {Offset} Sekunde in {location}
-wann Zeit wird es sein nach {Offset} Sekunden
-wann Zeit wird es sein nach {Offset} Sekunden in {location}
-wann Zeit wird es sein nach {Offset} Stunde
-wann Zeit wird es sein nach {Offset} Stunde in {location}
-wann Zeit wird es sein nach {Offset} Stunden
-wann Zeit wird es sein nach {Offset} Stunden in {location}
-wann Zeit wird es sein wenn ich warte {Offset} Minute
-wann Zeit wird es sein wenn ich warte {Offset} Minute in {location}
-wann Zeit wird es sein wenn ich warte {Offset} Minuten
-wann Zeit wird es sein wenn ich warte {Offset} Minuten in {location}
-wann Zeit wird es sein wenn ich warte {Offset} Sekunde
-wann Zeit wird es sein wenn ich warte {Offset} Sekunde in {location}
-wann Zeit wird es sein wenn ich warte {Offset} Sekunden
-wann Zeit wird es sein wenn ich warte {Offset} Sekunden in {location}
-wann Zeit wird es sein wenn ich warte {Offset} Stunde
-wann Zeit wird es sein wenn ich warte {Offset} Stunde in {location}
-wann Zeit wird es sein wenn ich warte {Offset} Stunden
-wann Zeit wird es sein wenn ich warte {Offset} Stunden in {location}
-wann Zeit wird es werden in {Offset} Minute
-wann Zeit wird es werden in {Offset} Minute in {location}
-wann Zeit wird es werden in {Offset} Minuten
-wann Zeit wird es werden in {Offset} Minuten in {location}
-wann Zeit wird es werden in {Offset} Sekunde
-wann Zeit wird es werden in {Offset} Sekunde in {location}
-wann Zeit wird es werden in {Offset} Sekunden
-wann Zeit wird es werden in {Offset} Sekunden in {location}
-wann Zeit wird es werden in {Offset} Stunde
-wann Zeit wird es werden in {Offset} Stunde in {location}
-wann Zeit wird es werden in {Offset} Stunden
-wann Zeit wird es werden in {Offset} Stunden in {location}
-wann Zeit wird es werden nach {Offset} Minute
-wann Zeit wird es werden nach {Offset} Minute in {location}
-wann Zeit wird es werden nach {Offset} Minuten
-wann Zeit wird es werden nach {Offset} Minuten in {location}
-wann Zeit wird es werden nach {Offset} Sekunde
-wann Zeit wird es werden nach {Offset} Sekunde in {location}
-wann Zeit wird es werden nach {Offset} Sekunden
-wann Zeit wird es werden nach {Offset} Sekunden in {location}
-wann Zeit wird es werden nach {Offset} Stunde
-wann Zeit wird es werden nach {Offset} Stunde in {location}
-wann Zeit wird es werden nach {Offset} Stunden
-wann Zeit wird es werden nach {Offset} Stunden in {location}
-wann Zeit wird es werden wenn ich warte {Offset} Minute
-wann Zeit wird es werden wenn ich warte {Offset} Minute in {location}
-wann Zeit wird es werden wenn ich warte {Offset} Minuten
-wann Zeit wird es werden wenn ich warte {Offset} Minuten in {location}
-wann Zeit wird es werden wenn ich warte {Offset} Sekunde
-wann Zeit wird es werden wenn ich warte {Offset} Sekunde in {location}
-wann Zeit wird es werden wenn ich warte {Offset} Sekunden
-wann Zeit wird es werden wenn ich warte {Offset} Sekunden in {location}
-wann Zeit wird es werden wenn ich warte {Offset} Stunde
-wann Zeit wird es werden wenn ich warte {Offset} Stunde in {location}
-wann Zeit wird es werden wenn ich warte {Offset} Stunden
-wann Zeit wird es werden wenn ich warte {Offset} Stunden in {location}
-wann Zeit wird es zeigen in {Offset} Minute
-wann Zeit wird es zeigen in {Offset} Minute in {location}
-wann Zeit wird es zeigen in {Offset} Minuten
-wann Zeit wird es zeigen in {Offset} Minuten in {location}
-wann Zeit wird es zeigen in {Offset} Sekunde
-wann Zeit wird es zeigen in {Offset} Sekunde in {location}
-wann Zeit wird es zeigen in {Offset} Sekunden
-wann Zeit wird es zeigen in {Offset} Sekunden in {location}
-wann Zeit wird es zeigen in {Offset} Stunde
-wann Zeit wird es zeigen in {Offset} Stunde in {location}
-wann Zeit wird es zeigen in {Offset} Stunden
-wann Zeit wird es zeigen in {Offset} Stunden in {location}
-wann Zeit wird es zeigen nach {Offset} Minute
-wann Zeit wird es zeigen nach {Offset} Minute in {location}
-wann Zeit wird es zeigen nach {Offset} Minuten
-wann Zeit wird es zeigen nach {Offset} Minuten in {location}
-wann Zeit wird es zeigen nach {Offset} Sekunde
-wann Zeit wird es zeigen nach {Offset} Sekunde in {location}
-wann Zeit wird es zeigen nach {Offset} Sekunden
-wann Zeit wird es zeigen nach {Offset} Sekunden in {location}
-wann Zeit wird es zeigen nach {Offset} Stunde
-wann Zeit wird es zeigen nach {Offset} Stunde in {location}
-wann Zeit wird es zeigen nach {Offset} Stunden
-wann Zeit wird es zeigen nach {Offset} Stunden in {location}
-wann Zeit wird es zeigen wenn ich warte {Offset} Minute
-wann Zeit wird es zeigen wenn ich warte {Offset} Minute in {location}
-wann Zeit wird es zeigen wenn ich warte {Offset} Minuten
-wann Zeit wird es zeigen wenn ich warte {Offset} Minuten in {location}
-wann Zeit wird es zeigen wenn ich warte {Offset} Sekunde
-wann Zeit wird es zeigen wenn ich warte {Offset} Sekunde in {location}
-wann Zeit wird es zeigen wenn ich warte {Offset} Sekunden
-wann Zeit wird es zeigen wenn ich warte {Offset} Sekunden in {location}
-wann Zeit wird es zeigen wenn ich warte {Offset} Stunde
-wann Zeit wird es zeigen wenn ich warte {Offset} Stunde in {location}
-wann Zeit wird es zeigen wenn ich warte {Offset} Stunden
-wann Zeit wird es zeigen wenn ich warte {Offset} Stunden in {location}
-wann ist es {Offset} Minuten
-wann ist es {Offset} Minuten  in {location}
-wann ist es {Offset} Minuten ab jetzt
-wann ist es {Offset} Minuten ab jetzt in {location}
-wann ist es {Offset} Sekunden
-wann ist es {Offset} Sekunden  in {location}
-wann ist es {Offset} Sekunden ab jetzt
-wann ist es {Offset} Sekunden ab jetzt in {location}
-wann ist es {Offset} Stunden
-wann ist es {Offset} Stunden  in {location}
-wann ist es {Offset} Stunden ab jetzt
-wann ist es {Offset} Stunden ab jetzt in {location}
-wann wird es sein {Offset} Minuten
-wann wird es sein {Offset} Minuten  in {location}
-wann wird es sein {Offset} Minuten ab jetzt
-wann wird es sein {Offset} Minuten ab jetzt in {location}
-wann wird es sein {Offset} Sekunden
-wann wird es sein {Offset} Sekunden  in {location}
-wann wird es sein {Offset} Sekunden ab jetzt
-wann wird es sein {Offset} Sekunden ab jetzt in {location}
-wann wird es sein {Offset} Stunden
-wann wird es sein {Offset} Stunden  in {location}
-wann wird es sein {Offset} Stunden ab jetzt
-wann wird es sein {Offset} Stunden ab jetzt in {location}
-was wird die Uhr anzeigen  nach {Offset}  Minute
-was wird die Uhr anzeigen  nach {Offset}  Minute  in {location}
-was wird die Uhr anzeigen  nach {Offset}  Minuten
-was wird die Uhr anzeigen  nach {Offset}  Minuten  in {location}
-was wird die Uhr anzeigen  nach {Offset}  Stunde
-was wird die Uhr anzeigen  nach {Offset}  Stunde in {location}
-was wird die Uhr anzeigen  nach {Offset}  Stunden
-was wird die Uhr anzeigen  nach {Offset}  Stunden in {location}
-was wird die Uhr anzeigen  nach {Offset} Sekunde
-was wird die Uhr anzeigen  nach {Offset} Sekunde  in {location}
-was wird die Uhr anzeigen  nach {Offset} Sekunden
-was wird die Uhr anzeigen  nach {Offset} Sekunden  in {location}
-was wird die Uhr anzeigen  wenn ich warte  {Offset}  Minute
-was wird die Uhr anzeigen  wenn ich warte  {Offset}  Minute  in {location}
-was wird die Uhr anzeigen  wenn ich warte  {Offset}  Minuten
-was wird die Uhr anzeigen  wenn ich warte  {Offset}  Minuten  in {location}
-was wird die Uhr anzeigen  wenn ich warte  {Offset}  Stunde
-was wird die Uhr anzeigen  wenn ich warte  {Offset}  Stunde in {location}
-was wird die Uhr anzeigen  wenn ich warte  {Offset}  Stunden
-was wird die Uhr anzeigen  wenn ich warte  {Offset}  Stunden in {location}
-was wird die Uhr anzeigen  wenn ich warte  {Offset} Sekunde
-was wird die Uhr anzeigen  wenn ich warte  {Offset} Sekunde  in {location}
-was wird die Uhr anzeigen  wenn ich warte  {Offset} Sekunden
-was wird die Uhr anzeigen  wenn ich warte  {Offset} Sekunden  in {location}
-was wird die Uhr anzeigen in  {Offset}  Minute
-was wird die Uhr anzeigen in  {Offset}  Minute  in {location}
-was wird die Uhr anzeigen in  {Offset}  Minuten
-was wird die Uhr anzeigen in  {Offset}  Minuten  in {location}
-was wird die Uhr anzeigen in  {Offset}  Stunde
-was wird die Uhr anzeigen in  {Offset}  Stunde in {location}
-was wird die Uhr anzeigen in  {Offset}  Stunden
-was wird die Uhr anzeigen in  {Offset}  Stunden in {location}
-was wird die Uhr anzeigen in  {Offset} Sekunde
-was wird die Uhr anzeigen in  {Offset} Sekunde  in {location}
-was wird die Uhr anzeigen in  {Offset} Sekunden
-was wird die Uhr anzeigen in  {Offset} Sekunden  in {location}
-wie spät ist es   nach {Offset}  Minute
-wie spät ist es   nach {Offset}  Minute  in {location}
-wie spät ist es   nach {Offset}  Minuten
-wie spät ist es   nach {Offset}  Minuten  in {location}
-wie spät ist es   nach {Offset}  Stunde
-wie spät ist es   nach {Offset}  Stunde in {location}
-wie spät ist es   nach {Offset}  Stunden
-wie spät ist es   nach {Offset}  Stunden in {location}
-wie spät ist es   nach {Offset} Sekunde
-wie spät ist es   nach {Offset} Sekunde  in {location}
-wie spät ist es   nach {Offset} Sekunden
-wie spät ist es   nach {Offset} Sekunden  in {location}
-wie spät ist es   wenn ich warte  {Offset}  Minute
-wie spät ist es   wenn ich warte  {Offset}  Minute  in {location}
-wie spät ist es   wenn ich warte  {Offset}  Minuten
-wie spät ist es   wenn ich warte  {Offset}  Minuten  in {location}
-wie spät ist es   wenn ich warte  {Offset}  Stunde
-wie spät ist es   wenn ich warte  {Offset}  Stunde in {location}
-wie spät ist es   wenn ich warte  {Offset}  Stunden
-wie spät ist es   wenn ich warte  {Offset}  Stunden in {location}
-wie spät ist es   wenn ich warte  {Offset} Sekunde
-wie spät ist es   wenn ich warte  {Offset} Sekunde  in {location}
-wie spät ist es   wenn ich warte  {Offset} Sekunden
-wie spät ist es   wenn ich warte  {Offset} Sekunden  in {location}
-wie spät ist es  in  {Offset}  Minute
-wie spät ist es  in  {Offset}  Minute  in {location}
-wie spät ist es  in  {Offset}  Minuten
-wie spät ist es  in  {Offset}  Minuten  in {location}
-wie spät ist es  in  {Offset}  Stunde
-wie spät ist es  in  {Offset}  Stunde in {location}
-wie spät ist es  in  {Offset}  Stunden
-wie spät ist es  in  {Offset}  Stunden in {location}
-wie spät ist es  in  {Offset} Sekunde
-wie spät ist es  in  {Offset} Sekunde  in {location}
-wie spät ist es  in  {Offset} Sekunden
-wie spät ist es  in  {Offset} Sekunden  in {location}
-zu welcher Zeit wird es sein in {Offset} Minute
-zu welcher Zeit wird es sein in {Offset} Minute in {location}
-zu welcher Zeit wird es sein in {Offset} Minuten
-zu welcher Zeit wird es sein in {Offset} Minuten in {location}
-zu welcher Zeit wird es sein in {Offset} Sekunde
-zu welcher Zeit wird es sein in {Offset} Sekunde in {location}
-zu welcher Zeit wird es sein in {Offset} Sekunden
-zu welcher Zeit wird es sein in {Offset} Sekunden in {location}
-zu welcher Zeit wird es sein in {Offset} Stunde
-zu welcher Zeit wird es sein in {Offset} Stunde in {location}
-zu welcher Zeit wird es sein in {Offset} Stunden
-zu welcher Zeit wird es sein in {Offset} Stunden in {location}
-zu welcher Zeit wird es sein nach {Offset} Minute
-zu welcher Zeit wird es sein nach {Offset} Minute in {location}
-zu welcher Zeit wird es sein nach {Offset} Minuten
-zu welcher Zeit wird es sein nach {Offset} Minuten in {location}
-zu welcher Zeit wird es sein nach {Offset} Sekunde
-zu welcher Zeit wird es sein nach {Offset} Sekunde in {location}
-zu welcher Zeit wird es sein nach {Offset} Sekunden
-zu welcher Zeit wird es sein nach {Offset} Sekunden in {location}
-zu welcher Zeit wird es sein nach {Offset} Stunde
-zu welcher Zeit wird es sein nach {Offset} Stunde in {location}
-zu welcher Zeit wird es sein nach {Offset} Stunden
-zu welcher Zeit wird es sein nach {Offset} Stunden in {location}
-zu welcher Zeit wird es sein wenn ich warte {Offset} Minute
-zu welcher Zeit wird es sein wenn ich warte {Offset} Minute in {location}
-zu welcher Zeit wird es sein wenn ich warte {Offset} Minuten
-zu welcher Zeit wird es sein wenn ich warte {Offset} Minuten in {location}
-zu welcher Zeit wird es sein wenn ich warte {Offset} Sekunde
-zu welcher Zeit wird es sein wenn ich warte {Offset} Sekunde in {location}
-zu welcher Zeit wird es sein wenn ich warte {Offset} Sekunden
-zu welcher Zeit wird es sein wenn ich warte {Offset} Sekunden in {location}
-zu welcher Zeit wird es sein wenn ich warte {Offset} Stunde
-zu welcher Zeit wird es sein wenn ich warte {Offset} Stunde in {location}
-zu welcher Zeit wird es sein wenn ich warte {Offset} Stunden
-zu welcher Zeit wird es sein wenn ich warte {Offset} Stunden in {location}
-zu welcher Zeit wird es werden in {Offset} Minute
-zu welcher Zeit wird es werden in {Offset} Minute in {location}
-zu welcher Zeit wird es werden in {Offset} Minuten
-zu welcher Zeit wird es werden in {Offset} Minuten in {location}
-zu welcher Zeit wird es werden in {Offset} Sekunde
-zu welcher Zeit wird es werden in {Offset} Sekunde in {location}
-zu welcher Zeit wird es werden in {Offset} Sekunden
-zu welcher Zeit wird es werden in {Offset} Sekunden in {location}
-zu welcher Zeit wird es werden in {Offset} Stunde
-zu welcher Zeit wird es werden in {Offset} Stunde in {location}
-zu welcher Zeit wird es werden in {Offset} Stunden
-zu welcher Zeit wird es werden in {Offset} Stunden in {location}
-zu welcher Zeit wird es werden nach {Offset} Minute
-zu welcher Zeit wird es werden nach {Offset} Minute in {location}
-zu welcher Zeit wird es werden nach {Offset} Minuten
-zu welcher Zeit wird es werden nach {Offset} Minuten in {location}
-zu welcher Zeit wird es werden nach {Offset} Sekunde
-zu welcher Zeit wird es werden nach {Offset} Sekunde in {location}
-zu welcher Zeit wird es werden nach {Offset} Sekunden
-zu welcher Zeit wird es werden nach {Offset} Sekunden in {location}
-zu welcher Zeit wird es werden nach {Offset} Stunde
-zu welcher Zeit wird es werden nach {Offset} Stunde in {location}
-zu welcher Zeit wird es werden nach {Offset} Stunden
-zu welcher Zeit wird es werden nach {Offset} Stunden in {location}
-zu welcher Zeit wird es werden wenn ich warte {Offset} Minute
-zu welcher Zeit wird es werden wenn ich warte {Offset} Minute in {location}
-zu welcher Zeit wird es werden wenn ich warte {Offset} Minuten
-zu welcher Zeit wird es werden wenn ich warte {Offset} Minuten in {location}
-zu welcher Zeit wird es werden wenn ich warte {Offset} Sekunde
-zu welcher Zeit wird es werden wenn ich warte {Offset} Sekunde in {location}
-zu welcher Zeit wird es werden wenn ich warte {Offset} Sekunden
-zu welcher Zeit wird es werden wenn ich warte {Offset} Sekunden in {location}
-zu welcher Zeit wird es werden wenn ich warte {Offset} Stunde
-zu welcher Zeit wird es werden wenn ich warte {Offset} Stunde in {location}
-zu welcher Zeit wird es werden wenn ich warte {Offset} Stunden
-zu welcher Zeit wird es werden wenn ich warte {Offset} Stunden in {location}
-zu welcher Zeit wird es zeigen in {Offset} Minute
-zu welcher Zeit wird es zeigen in {Offset} Minute in {location}
-zu welcher Zeit wird es zeigen in {Offset} Minuten
-zu welcher Zeit wird es zeigen in {Offset} Minuten in {location}
-zu welcher Zeit wird es zeigen in {Offset} Sekunde
-zu welcher Zeit wird es zeigen in {Offset} Sekunde in {location}
-zu welcher Zeit wird es zeigen in {Offset} Sekunden
-zu welcher Zeit wird es zeigen in {Offset} Sekunden in {location}
-zu welcher Zeit wird es zeigen in {Offset} Stunde
-zu welcher Zeit wird es zeigen in {Offset} Stunde in {location}
-zu welcher Zeit wird es zeigen in {Offset} Stunden
-zu welcher Zeit wird es zeigen in {Offset} Stunden in {location}
-zu welcher Zeit wird es zeigen nach {Offset} Minute
-zu welcher Zeit wird es zeigen nach {Offset} Minute in {location}
-zu welcher Zeit wird es zeigen nach {Offset} Minuten
-zu welcher Zeit wird es zeigen nach {Offset} Minuten in {location}
-zu welcher Zeit wird es zeigen nach {Offset} Sekunde
-zu welcher Zeit wird es zeigen nach {Offset} Sekunde in {location}
-zu welcher Zeit wird es zeigen nach {Offset} Sekunden
-zu welcher Zeit wird es zeigen nach {Offset} Sekunden in {location}
-zu welcher Zeit wird es zeigen nach {Offset} Stunde
-zu welcher Zeit wird es zeigen nach {Offset} Stunde in {location}
-zu welcher Zeit wird es zeigen nach {Offset} Stunden
-zu welcher Zeit wird es zeigen nach {Offset} Stunden in {location}
-zu welcher Zeit wird es zeigen wenn ich warte {Offset} Minute
-zu welcher Zeit wird es zeigen wenn ich warte {Offset} Minute in {location}
-zu welcher Zeit wird es zeigen wenn ich warte {Offset} Minuten
-zu welcher Zeit wird es zeigen wenn ich warte {Offset} Minuten in {location}
-zu welcher Zeit wird es zeigen wenn ich warte {Offset} Sekunde
-zu welcher Zeit wird es zeigen wenn ich warte {Offset} Sekunde in {location}
-zu welcher Zeit wird es zeigen wenn ich warte {Offset} Sekunden
-zu welcher Zeit wird es zeigen wenn ich warte {Offset} Sekunden in {location}
-zu welcher Zeit wird es zeigen wenn ich warte {Offset} Stunde
-zu welcher Zeit wird es zeigen wenn ich warte {Offset} Stunde in {location}
-zu welcher Zeit wird es zeigen wenn ich warte {Offset} Stunden
-zu welcher Zeit wird es zeigen wenn ich warte {Offset} Stunden in {location}
+um wie viel Uhr ist es {offset} Minuten
+um wie viel Uhr ist es {offset} Minuten  in {location}
+um wie viel Uhr ist es {offset} Minuten ab jetzt
+um wie viel Uhr ist es {offset} Minuten ab jetzt in {location}
+um wie viel Uhr ist es {offset} Sekunden
+um wie viel Uhr ist es {offset} Sekunden  in {location}
+um wie viel Uhr ist es {offset} Sekunden ab jetzt
+um wie viel Uhr ist es {offset} Sekunden ab jetzt in {location}
+um wie viel Uhr ist es {offset} Stunden
+um wie viel Uhr ist es {offset} Stunden  in {location}
+um wie viel Uhr ist es {offset} Stunden ab jetzt
+um wie viel Uhr ist es {offset} Stunden ab jetzt in {location}
+um wie viel Uhr wird es sein {offset} Minuten
+um wie viel Uhr wird es sein {offset} Minuten  in {location}
+um wie viel Uhr wird es sein {offset} Minuten ab jetzt
+um wie viel Uhr wird es sein {offset} Minuten ab jetzt in {location}
+um wie viel Uhr wird es sein {offset} Sekunden
+um wie viel Uhr wird es sein {offset} Sekunden  in {location}
+um wie viel Uhr wird es sein {offset} Sekunden ab jetzt
+um wie viel Uhr wird es sein {offset} Sekunden ab jetzt in {location}
+um wie viel Uhr wird es sein {offset} Stunden
+um wie viel Uhr wird es sein {offset} Stunden  in {location}
+um wie viel Uhr wird es sein {offset} Stunden ab jetzt
+um wie viel Uhr wird es sein {offset} Stunden ab jetzt in {location}
+wann Zeit wird es sein in {offset} Minute
+wann Zeit wird es sein in {offset} Minute in {location}
+wann Zeit wird es sein in {offset} Minuten
+wann Zeit wird es sein in {offset} Minuten in {location}
+wann Zeit wird es sein in {offset} Sekunde
+wann Zeit wird es sein in {offset} Sekunde in {location}
+wann Zeit wird es sein in {offset} Sekunden
+wann Zeit wird es sein in {offset} Sekunden in {location}
+wann Zeit wird es sein in {offset} Stunde
+wann Zeit wird es sein in {offset} Stunde in {location}
+wann Zeit wird es sein in {offset} Stunden
+wann Zeit wird es sein in {offset} Stunden in {location}
+wann Zeit wird es sein nach {offset} Minute
+wann Zeit wird es sein nach {offset} Minute in {location}
+wann Zeit wird es sein nach {offset} Minuten
+wann Zeit wird es sein nach {offset} Minuten in {location}
+wann Zeit wird es sein nach {offset} Sekunde
+wann Zeit wird es sein nach {offset} Sekunde in {location}
+wann Zeit wird es sein nach {offset} Sekunden
+wann Zeit wird es sein nach {offset} Sekunden in {location}
+wann Zeit wird es sein nach {offset} Stunde
+wann Zeit wird es sein nach {offset} Stunde in {location}
+wann Zeit wird es sein nach {offset} Stunden
+wann Zeit wird es sein nach {offset} Stunden in {location}
+wann Zeit wird es sein wenn ich warte {offset} Minute
+wann Zeit wird es sein wenn ich warte {offset} Minute in {location}
+wann Zeit wird es sein wenn ich warte {offset} Minuten
+wann Zeit wird es sein wenn ich warte {offset} Minuten in {location}
+wann Zeit wird es sein wenn ich warte {offset} Sekunde
+wann Zeit wird es sein wenn ich warte {offset} Sekunde in {location}
+wann Zeit wird es sein wenn ich warte {offset} Sekunden
+wann Zeit wird es sein wenn ich warte {offset} Sekunden in {location}
+wann Zeit wird es sein wenn ich warte {offset} Stunde
+wann Zeit wird es sein wenn ich warte {offset} Stunde in {location}
+wann Zeit wird es sein wenn ich warte {offset} Stunden
+wann Zeit wird es sein wenn ich warte {offset} Stunden in {location}
+wann Zeit wird es werden in {offset} Minute
+wann Zeit wird es werden in {offset} Minute in {location}
+wann Zeit wird es werden in {offset} Minuten
+wann Zeit wird es werden in {offset} Minuten in {location}
+wann Zeit wird es werden in {offset} Sekunde
+wann Zeit wird es werden in {offset} Sekunde in {location}
+wann Zeit wird es werden in {offset} Sekunden
+wann Zeit wird es werden in {offset} Sekunden in {location}
+wann Zeit wird es werden in {offset} Stunde
+wann Zeit wird es werden in {offset} Stunde in {location}
+wann Zeit wird es werden in {offset} Stunden
+wann Zeit wird es werden in {offset} Stunden in {location}
+wann Zeit wird es werden nach {offset} Minute
+wann Zeit wird es werden nach {offset} Minute in {location}
+wann Zeit wird es werden nach {offset} Minuten
+wann Zeit wird es werden nach {offset} Minuten in {location}
+wann Zeit wird es werden nach {offset} Sekunde
+wann Zeit wird es werden nach {offset} Sekunde in {location}
+wann Zeit wird es werden nach {offset} Sekunden
+wann Zeit wird es werden nach {offset} Sekunden in {location}
+wann Zeit wird es werden nach {offset} Stunde
+wann Zeit wird es werden nach {offset} Stunde in {location}
+wann Zeit wird es werden nach {offset} Stunden
+wann Zeit wird es werden nach {offset} Stunden in {location}
+wann Zeit wird es werden wenn ich warte {offset} Minute
+wann Zeit wird es werden wenn ich warte {offset} Minute in {location}
+wann Zeit wird es werden wenn ich warte {offset} Minuten
+wann Zeit wird es werden wenn ich warte {offset} Minuten in {location}
+wann Zeit wird es werden wenn ich warte {offset} Sekunde
+wann Zeit wird es werden wenn ich warte {offset} Sekunde in {location}
+wann Zeit wird es werden wenn ich warte {offset} Sekunden
+wann Zeit wird es werden wenn ich warte {offset} Sekunden in {location}
+wann Zeit wird es werden wenn ich warte {offset} Stunde
+wann Zeit wird es werden wenn ich warte {offset} Stunde in {location}
+wann Zeit wird es werden wenn ich warte {offset} Stunden
+wann Zeit wird es werden wenn ich warte {offset} Stunden in {location}
+wann Zeit wird es zeigen in {offset} Minute
+wann Zeit wird es zeigen in {offset} Minute in {location}
+wann Zeit wird es zeigen in {offset} Minuten
+wann Zeit wird es zeigen in {offset} Minuten in {location}
+wann Zeit wird es zeigen in {offset} Sekunde
+wann Zeit wird es zeigen in {offset} Sekunde in {location}
+wann Zeit wird es zeigen in {offset} Sekunden
+wann Zeit wird es zeigen in {offset} Sekunden in {location}
+wann Zeit wird es zeigen in {offset} Stunde
+wann Zeit wird es zeigen in {offset} Stunde in {location}
+wann Zeit wird es zeigen in {offset} Stunden
+wann Zeit wird es zeigen in {offset} Stunden in {location}
+wann Zeit wird es zeigen nach {offset} Minute
+wann Zeit wird es zeigen nach {offset} Minute in {location}
+wann Zeit wird es zeigen nach {offset} Minuten
+wann Zeit wird es zeigen nach {offset} Minuten in {location}
+wann Zeit wird es zeigen nach {offset} Sekunde
+wann Zeit wird es zeigen nach {offset} Sekunde in {location}
+wann Zeit wird es zeigen nach {offset} Sekunden
+wann Zeit wird es zeigen nach {offset} Sekunden in {location}
+wann Zeit wird es zeigen nach {offset} Stunde
+wann Zeit wird es zeigen nach {offset} Stunde in {location}
+wann Zeit wird es zeigen nach {offset} Stunden
+wann Zeit wird es zeigen nach {offset} Stunden in {location}
+wann Zeit wird es zeigen wenn ich warte {offset} Minute
+wann Zeit wird es zeigen wenn ich warte {offset} Minute in {location}
+wann Zeit wird es zeigen wenn ich warte {offset} Minuten
+wann Zeit wird es zeigen wenn ich warte {offset} Minuten in {location}
+wann Zeit wird es zeigen wenn ich warte {offset} Sekunde
+wann Zeit wird es zeigen wenn ich warte {offset} Sekunde in {location}
+wann Zeit wird es zeigen wenn ich warte {offset} Sekunden
+wann Zeit wird es zeigen wenn ich warte {offset} Sekunden in {location}
+wann Zeit wird es zeigen wenn ich warte {offset} Stunde
+wann Zeit wird es zeigen wenn ich warte {offset} Stunde in {location}
+wann Zeit wird es zeigen wenn ich warte {offset} Stunden
+wann Zeit wird es zeigen wenn ich warte {offset} Stunden in {location}
+wann ist es {offset} Minuten
+wann ist es {offset} Minuten  in {location}
+wann ist es {offset} Minuten ab jetzt
+wann ist es {offset} Minuten ab jetzt in {location}
+wann ist es {offset} Sekunden
+wann ist es {offset} Sekunden  in {location}
+wann ist es {offset} Sekunden ab jetzt
+wann ist es {offset} Sekunden ab jetzt in {location}
+wann ist es {offset} Stunden
+wann ist es {offset} Stunden  in {location}
+wann ist es {offset} Stunden ab jetzt
+wann ist es {offset} Stunden ab jetzt in {location}
+wann wird es sein {offset} Minuten
+wann wird es sein {offset} Minuten  in {location}
+wann wird es sein {offset} Minuten ab jetzt
+wann wird es sein {offset} Minuten ab jetzt in {location}
+wann wird es sein {offset} Sekunden
+wann wird es sein {offset} Sekunden  in {location}
+wann wird es sein {offset} Sekunden ab jetzt
+wann wird es sein {offset} Sekunden ab jetzt in {location}
+wann wird es sein {offset} Stunden
+wann wird es sein {offset} Stunden  in {location}
+wann wird es sein {offset} Stunden ab jetzt
+wann wird es sein {offset} Stunden ab jetzt in {location}
+was wird die Uhr anzeigen  nach {offset}  Minute
+was wird die Uhr anzeigen  nach {offset}  Minute  in {location}
+was wird die Uhr anzeigen  nach {offset}  Minuten
+was wird die Uhr anzeigen  nach {offset}  Minuten  in {location}
+was wird die Uhr anzeigen  nach {offset}  Stunde
+was wird die Uhr anzeigen  nach {offset}  Stunde in {location}
+was wird die Uhr anzeigen  nach {offset}  Stunden
+was wird die Uhr anzeigen  nach {offset}  Stunden in {location}
+was wird die Uhr anzeigen  nach {offset} Sekunde
+was wird die Uhr anzeigen  nach {offset} Sekunde  in {location}
+was wird die Uhr anzeigen  nach {offset} Sekunden
+was wird die Uhr anzeigen  nach {offset} Sekunden  in {location}
+was wird die Uhr anzeigen  wenn ich warte  {offset}  Minute
+was wird die Uhr anzeigen  wenn ich warte  {offset}  Minute  in {location}
+was wird die Uhr anzeigen  wenn ich warte  {offset}  Minuten
+was wird die Uhr anzeigen  wenn ich warte  {offset}  Minuten  in {location}
+was wird die Uhr anzeigen  wenn ich warte  {offset}  Stunde
+was wird die Uhr anzeigen  wenn ich warte  {offset}  Stunde in {location}
+was wird die Uhr anzeigen  wenn ich warte  {offset}  Stunden
+was wird die Uhr anzeigen  wenn ich warte  {offset}  Stunden in {location}
+was wird die Uhr anzeigen  wenn ich warte  {offset} Sekunde
+was wird die Uhr anzeigen  wenn ich warte  {offset} Sekunde  in {location}
+was wird die Uhr anzeigen  wenn ich warte  {offset} Sekunden
+was wird die Uhr anzeigen  wenn ich warte  {offset} Sekunden  in {location}
+was wird die Uhr anzeigen in  {offset}  Minute
+was wird die Uhr anzeigen in  {offset}  Minute  in {location}
+was wird die Uhr anzeigen in  {offset}  Minuten
+was wird die Uhr anzeigen in  {offset}  Minuten  in {location}
+was wird die Uhr anzeigen in  {offset}  Stunde
+was wird die Uhr anzeigen in  {offset}  Stunde in {location}
+was wird die Uhr anzeigen in  {offset}  Stunden
+was wird die Uhr anzeigen in  {offset}  Stunden in {location}
+was wird die Uhr anzeigen in  {offset} Sekunde
+was wird die Uhr anzeigen in  {offset} Sekunde  in {location}
+was wird die Uhr anzeigen in  {offset} Sekunden
+was wird die Uhr anzeigen in  {offset} Sekunden  in {location}
+wie spät ist es   nach {offset}  Minute
+wie spät ist es   nach {offset}  Minute  in {location}
+wie spät ist es   nach {offset}  Minuten
+wie spät ist es   nach {offset}  Minuten  in {location}
+wie spät ist es   nach {offset}  Stunde
+wie spät ist es   nach {offset}  Stunde in {location}
+wie spät ist es   nach {offset}  Stunden
+wie spät ist es   nach {offset}  Stunden in {location}
+wie spät ist es   nach {offset} Sekunde
+wie spät ist es   nach {offset} Sekunde  in {location}
+wie spät ist es   nach {offset} Sekunden
+wie spät ist es   nach {offset} Sekunden  in {location}
+wie spät ist es   wenn ich warte  {offset}  Minute
+wie spät ist es   wenn ich warte  {offset}  Minute  in {location}
+wie spät ist es   wenn ich warte  {offset}  Minuten
+wie spät ist es   wenn ich warte  {offset}  Minuten  in {location}
+wie spät ist es   wenn ich warte  {offset}  Stunde
+wie spät ist es   wenn ich warte  {offset}  Stunde in {location}
+wie spät ist es   wenn ich warte  {offset}  Stunden
+wie spät ist es   wenn ich warte  {offset}  Stunden in {location}
+wie spät ist es   wenn ich warte  {offset} Sekunde
+wie spät ist es   wenn ich warte  {offset} Sekunde  in {location}
+wie spät ist es   wenn ich warte  {offset} Sekunden
+wie spät ist es   wenn ich warte  {offset} Sekunden  in {location}
+wie spät ist es  in  {offset}  Minute
+wie spät ist es  in  {offset}  Minute  in {location}
+wie spät ist es  in  {offset}  Minuten
+wie spät ist es  in  {offset}  Minuten  in {location}
+wie spät ist es  in  {offset}  Stunde
+wie spät ist es  in  {offset}  Stunde in {location}
+wie spät ist es  in  {offset}  Stunden
+wie spät ist es  in  {offset}  Stunden in {location}
+wie spät ist es  in  {offset} Sekunde
+wie spät ist es  in  {offset} Sekunde  in {location}
+wie spät ist es  in  {offset} Sekunden
+wie spät ist es  in  {offset} Sekunden  in {location}
+zu welcher Zeit wird es sein in {offset} Minute
+zu welcher Zeit wird es sein in {offset} Minute in {location}
+zu welcher Zeit wird es sein in {offset} Minuten
+zu welcher Zeit wird es sein in {offset} Minuten in {location}
+zu welcher Zeit wird es sein in {offset} Sekunde
+zu welcher Zeit wird es sein in {offset} Sekunde in {location}
+zu welcher Zeit wird es sein in {offset} Sekunden
+zu welcher Zeit wird es sein in {offset} Sekunden in {location}
+zu welcher Zeit wird es sein in {offset} Stunde
+zu welcher Zeit wird es sein in {offset} Stunde in {location}
+zu welcher Zeit wird es sein in {offset} Stunden
+zu welcher Zeit wird es sein in {offset} Stunden in {location}
+zu welcher Zeit wird es sein nach {offset} Minute
+zu welcher Zeit wird es sein nach {offset} Minute in {location}
+zu welcher Zeit wird es sein nach {offset} Minuten
+zu welcher Zeit wird es sein nach {offset} Minuten in {location}
+zu welcher Zeit wird es sein nach {offset} Sekunde
+zu welcher Zeit wird es sein nach {offset} Sekunde in {location}
+zu welcher Zeit wird es sein nach {offset} Sekunden
+zu welcher Zeit wird es sein nach {offset} Sekunden in {location}
+zu welcher Zeit wird es sein nach {offset} Stunde
+zu welcher Zeit wird es sein nach {offset} Stunde in {location}
+zu welcher Zeit wird es sein nach {offset} Stunden
+zu welcher Zeit wird es sein nach {offset} Stunden in {location}
+zu welcher Zeit wird es sein wenn ich warte {offset} Minute
+zu welcher Zeit wird es sein wenn ich warte {offset} Minute in {location}
+zu welcher Zeit wird es sein wenn ich warte {offset} Minuten
+zu welcher Zeit wird es sein wenn ich warte {offset} Minuten in {location}
+zu welcher Zeit wird es sein wenn ich warte {offset} Sekunde
+zu welcher Zeit wird es sein wenn ich warte {offset} Sekunde in {location}
+zu welcher Zeit wird es sein wenn ich warte {offset} Sekunden
+zu welcher Zeit wird es sein wenn ich warte {offset} Sekunden in {location}
+zu welcher Zeit wird es sein wenn ich warte {offset} Stunde
+zu welcher Zeit wird es sein wenn ich warte {offset} Stunde in {location}
+zu welcher Zeit wird es sein wenn ich warte {offset} Stunden
+zu welcher Zeit wird es sein wenn ich warte {offset} Stunden in {location}
+zu welcher Zeit wird es werden in {offset} Minute
+zu welcher Zeit wird es werden in {offset} Minute in {location}
+zu welcher Zeit wird es werden in {offset} Minuten
+zu welcher Zeit wird es werden in {offset} Minuten in {location}
+zu welcher Zeit wird es werden in {offset} Sekunde
+zu welcher Zeit wird es werden in {offset} Sekunde in {location}
+zu welcher Zeit wird es werden in {offset} Sekunden
+zu welcher Zeit wird es werden in {offset} Sekunden in {location}
+zu welcher Zeit wird es werden in {offset} Stunde
+zu welcher Zeit wird es werden in {offset} Stunde in {location}
+zu welcher Zeit wird es werden in {offset} Stunden
+zu welcher Zeit wird es werden in {offset} Stunden in {location}
+zu welcher Zeit wird es werden nach {offset} Minute
+zu welcher Zeit wird es werden nach {offset} Minute in {location}
+zu welcher Zeit wird es werden nach {offset} Minuten
+zu welcher Zeit wird es werden nach {offset} Minuten in {location}
+zu welcher Zeit wird es werden nach {offset} Sekunde
+zu welcher Zeit wird es werden nach {offset} Sekunde in {location}
+zu welcher Zeit wird es werden nach {offset} Sekunden
+zu welcher Zeit wird es werden nach {offset} Sekunden in {location}
+zu welcher Zeit wird es werden nach {offset} Stunde
+zu welcher Zeit wird es werden nach {offset} Stunde in {location}
+zu welcher Zeit wird es werden nach {offset} Stunden
+zu welcher Zeit wird es werden nach {offset} Stunden in {location}
+zu welcher Zeit wird es werden wenn ich warte {offset} Minute
+zu welcher Zeit wird es werden wenn ich warte {offset} Minute in {location}
+zu welcher Zeit wird es werden wenn ich warte {offset} Minuten
+zu welcher Zeit wird es werden wenn ich warte {offset} Minuten in {location}
+zu welcher Zeit wird es werden wenn ich warte {offset} Sekunde
+zu welcher Zeit wird es werden wenn ich warte {offset} Sekunde in {location}
+zu welcher Zeit wird es werden wenn ich warte {offset} Sekunden
+zu welcher Zeit wird es werden wenn ich warte {offset} Sekunden in {location}
+zu welcher Zeit wird es werden wenn ich warte {offset} Stunde
+zu welcher Zeit wird es werden wenn ich warte {offset} Stunde in {location}
+zu welcher Zeit wird es werden wenn ich warte {offset} Stunden
+zu welcher Zeit wird es werden wenn ich warte {offset} Stunden in {location}
+zu welcher Zeit wird es zeigen in {offset} Minute
+zu welcher Zeit wird es zeigen in {offset} Minute in {location}
+zu welcher Zeit wird es zeigen in {offset} Minuten
+zu welcher Zeit wird es zeigen in {offset} Minuten in {location}
+zu welcher Zeit wird es zeigen in {offset} Sekunde
+zu welcher Zeit wird es zeigen in {offset} Sekunde in {location}
+zu welcher Zeit wird es zeigen in {offset} Sekunden
+zu welcher Zeit wird es zeigen in {offset} Sekunden in {location}
+zu welcher Zeit wird es zeigen in {offset} Stunde
+zu welcher Zeit wird es zeigen in {offset} Stunde in {location}
+zu welcher Zeit wird es zeigen in {offset} Stunden
+zu welcher Zeit wird es zeigen in {offset} Stunden in {location}
+zu welcher Zeit wird es zeigen nach {offset} Minute
+zu welcher Zeit wird es zeigen nach {offset} Minute in {location}
+zu welcher Zeit wird es zeigen nach {offset} Minuten
+zu welcher Zeit wird es zeigen nach {offset} Minuten in {location}
+zu welcher Zeit wird es zeigen nach {offset} Sekunde
+zu welcher Zeit wird es zeigen nach {offset} Sekunde in {location}
+zu welcher Zeit wird es zeigen nach {offset} Sekunden
+zu welcher Zeit wird es zeigen nach {offset} Sekunden in {location}
+zu welcher Zeit wird es zeigen nach {offset} Stunde
+zu welcher Zeit wird es zeigen nach {offset} Stunde in {location}
+zu welcher Zeit wird es zeigen nach {offset} Stunden
+zu welcher Zeit wird es zeigen nach {offset} Stunden in {location}
+zu welcher Zeit wird es zeigen wenn ich warte {offset} Minute
+zu welcher Zeit wird es zeigen wenn ich warte {offset} Minute in {location}
+zu welcher Zeit wird es zeigen wenn ich warte {offset} Minuten
+zu welcher Zeit wird es zeigen wenn ich warte {offset} Minuten in {location}
+zu welcher Zeit wird es zeigen wenn ich warte {offset} Sekunde
+zu welcher Zeit wird es zeigen wenn ich warte {offset} Sekunde in {location}
+zu welcher Zeit wird es zeigen wenn ich warte {offset} Sekunden
+zu welcher Zeit wird es zeigen wenn ich warte {offset} Sekunden in {location}
+zu welcher Zeit wird es zeigen wenn ich warte {offset} Stunde
+zu welcher Zeit wird es zeigen wenn ich warte {offset} Stunde in {location}
+zu welcher Zeit wird es zeigen wenn ich warte {offset} Stunden
+zu welcher Zeit wird es zeigen wenn ich warte {offset} Stunden in {location}

--- a/locale/es-ES/intents/what.time.is.it.intent
+++ b/locale/es-ES/intents/what.time.is.it.intent
@@ -118,8 +118,8 @@ tiempo correcto ahora en {location}
 ¿tienes? la hora actual en {location}
 ¿ya es mañana ?
 ¿ya es mañana en {location}?
-¿ya es mediodía|medianoche|la una|las dos|las tres|las cuatro|las cinco|las seis|las siete|las ocho|las nueve|las diez|las once|las doce)
-¿ya es mediodía|medianoche|la una|las dos|las tres|las cuatro|las cinco|las seis|las siete|las ocho|las nueve|las diez|las once|las doce) en {location}?
+¿ya es (mediodía|medianoche|la una|las dos|las tres|las cuatro|las cinco|las seis|las siete|las ocho|las nueve|las diez|las once|las doce)
+¿ya es (mediodía|medianoche|la una|las dos|las tres|las cuatro|las cinco|las seis|las siete|las ocho|las nueve|las diez|las once|las doce) en {location}?
 ¿ya es noche ?
 ¿ya es noche en {location}?
 ¿ya es tarde ?

--- a/locale/gl-ES/intents/current_date.intent
+++ b/locale/gl-ES/intents/current_date.intent
@@ -12,7 +12,7 @@ cal día, mes e ano é en {location}
 cal día, mes e ano é hoxe
 cal é a data completa
 cal é a data completa actual
-cal é a data completa actual en {localización}
+cal é a data completa actual en {location}
 cal é a data completa con ano de
 cal é a data completa con ano de en {location}
 cal é a data completa con ano de hoxe
@@ -22,12 +22,12 @@ cal é a data completa con ano é hoxe
 cal é a data completa de
 cal é a data completa de en {location}
 cal é a data completa de hoxe
-cal é a data completa de hoxe en {localización}
+cal é a data completa de hoxe en {location}
 cal é a data completa de hoxe, incluíndo o ano
 cal é a data completa en {location}
 cal é a data completa hoxe
 cal é a data completa neste momento
-cal é a data completa neste momento en {localización}
+cal é a data completa neste momento en {location}
 cal é a data completa é
 cal é a data completa é en {location}
 cal é a data completa é hoxe
@@ -59,8 +59,8 @@ dime a data completa de hoxe
 dime a data de hoxe
 dime a data de hoxe en {location}
 dime a data do calendario
-dime a data do calendario en {localización}
-dime a data en {localización}
+dime a data do calendario en {location}
+dime a data en {location}
 dime o día e mes
 dime o día, mes e ano
 dáme a data
@@ -68,12 +68,12 @@ dáme a data completa
 dáme a data completa de hoxe
 dáme a data completa de hoxe en {location}
 dáme a data do calendario
-dáme a data do calendario en {localización}
-dáme a data en {localización}
+dáme a data do calendario en {location}
+dáme a data en {location}
 móstrame a data
 móstrame a data do calendario
-móstrame a data do calendario en {localización}
-móstrame a data en {localización}
+móstrame a data do calendario en {location}
+móstrame a data en {location}
 necesito saber a data
 necesito saber a data en {location}
 necesito saber a data hoxe

--- a/locale/gl-ES/intents/weekday.for.date.intent
+++ b/locale/gl-ES/intents/weekday.for.date.intent
@@ -6,14 +6,14 @@ dime o día da semana do {date}
 dime o día da semana para o {date}
 dime o día de semana do {date}
 dime o día de semana para o {date}
-dime que día da semana foi  {data}
-dime que día da semana foi o {data}
-dime que día da semana é  {data}
-dime que día da semana é o {data}
-dime que día de semana foi  {data}
-dime que día de semana foi o {data}
-dime que día de semana é  {data}
-dime que día de semana é o {data}
+dime que día da semana foi  {date}
+dime que día da semana foi o {date}
+dime que día da semana é  {date}
+dime que día da semana é o {date}
+dime que día de semana foi  {date}
+dime que día de semana foi o {date}
+dime que día de semana é  {date}
+dime que día de semana é o {date}
 en que día da semana cae  {date}
 en que día da semana cae o {date}
 en que día de semana cae  {date}
@@ -50,58 +50,58 @@ pódesme dicir o día da semana do {date}
 pódesme dicir o día da semana para o {date}
 pódesme dicir o día de semana do {date}
 pódesme dicir o día de semana para o {date}
-pódesme dicir que día da semana foi  {data}
-pódesme dicir que día da semana foi o {data}
-pódesme dicir que día da semana é  {data}
-pódesme dicir que día da semana é o {data}
-pódesme dicir que día de semana foi  {data}
-pódesme dicir que día de semana foi o {data}
-pódesme dicir que día de semana é  {data}
-pódesme dicir que día de semana é o {data}
+pódesme dicir que día da semana foi  {date}
+pódesme dicir que día da semana foi o {date}
+pódesme dicir que día da semana é  {date}
+pódesme dicir que día da semana é o {date}
+pódesme dicir que día de semana foi  {date}
+pódesme dicir que día de semana foi o {date}
+pódesme dicir que día de semana é  {date}
+pódesme dicir que día de semana é o {date}
 que día da semana era  {date}
 que día da semana era o {date}
-que día da semana foi  {data}
 que día da semana foi  {date}
-que día da semana foi o {data}
+que día da semana foi  {date}
+que día da semana foi o {date}
 que día da semana foi o {date}
 que día da semana vai ser  {date}
 que día da semana vai ser o {date}
-que día da semana é  {data}
 que día da semana é  {date}
-que día da semana é o {data}
+que día da semana é  {date}
+que día da semana é o {date}
 que día da semana é o {date}
 que día de semana era  {date}
 que día de semana era o {date}
-que día de semana foi  {data}
 que día de semana foi  {date}
-que día de semana foi o {data}
+que día de semana foi  {date}
+que día de semana foi o {date}
 que día de semana foi o {date}
 que día de semana vai ser  {date}
 que día de semana vai ser o {date}
-que día de semana é  {data}
 que día de semana é  {date}
-que día de semana é o {data}
+que día de semana é  {date}
 que día de semana é o {date}
-quero saber que día da semana foi  {data}
-quero saber que día da semana foi o {data}
-quero saber que día da semana é  {data}
-quero saber que día da semana é o {data}
-quero saber que día de semana foi  {data}
-quero saber que día de semana foi o {data}
-quero saber que día de semana é  {data}
-quero saber que día de semana é o {data}
+que día de semana é o {date}
+quero saber que día da semana foi  {date}
+quero saber que día da semana foi o {date}
+quero saber que día da semana é  {date}
+quero saber que día da semana é o {date}
+quero saber que día de semana foi  {date}
+quero saber que día de semana foi o {date}
+quero saber que día de semana é  {date}
+quero saber que día de semana é o {date}
 sabes o día da semana do {date}
 sabes o día da semana para o {date}
 sabes o día de semana do {date}
 sabes o día de semana para o {date}
-sabes que día da semana foi  {data}
-sabes que día da semana foi o {data}
-sabes que día da semana é  {data}
-sabes que día da semana é o {data}
-sabes que día de semana foi  {data}
-sabes que día de semana foi o {data}
-sabes que día de semana é  {data}
-sabes que día de semana é o {data}
+sabes que día da semana foi  {date}
+sabes que día da semana foi o {date}
+sabes que día da semana é  {date}
+sabes que día da semana é o {date}
+sabes que día de semana foi  {date}
+sabes que día de semana foi o {date}
+sabes que día de semana é  {date}
+sabes que día de semana é o {date}
 {date} foi  domingo
 {date} foi  luns
 {date} foi  martes

--- a/locale/hu-HU/intents/what.time.will.it.be.intent
+++ b/locale/hu-HU/intents/what.time.will.it.be.intent
@@ -1,5 +1,4 @@
 hány óra lesz {offset} perc múlva {location}-ben
-hány óra lesz {offset} perc múlva {location}-ben {offset} perc múlva
 hány óra lesz {offset} óra múlva {location}-ben
 hány óra lesz {offset} órakor {location} órakor
 hány óra múlva lesz {offset} óra
@@ -15,13 +14,8 @@ mikor lesz ez {offset} másodperc múlva {location}-ben
 mikor lesz ez {offset} perc múlva
 mikor lesz ez {offset} óra múlva
 mikor lesz {offset} másodperc
-mikor lesz {offset} másodperc {location}-ben {location}
 mikor lesz {offset} perc
-mikor lesz {offset} perc mától {location}-ben {offset} perc múlva
-mikor lesz {offset} perc {location}-ben {offset} percben
 mikor lesz {offset} óra
-mikor lesz {offset} óra mától {location}-ben {offset} óra múlva
-mikor lesz {offset} óra {location}-ben {offset} óra
 mikor van ez {offset} másodperc
 mikor van ez {offset} másodperc múlva
 mikor van ez {offset} perc

--- a/locale/nl-NL/intents/what.time.will.it.be.intent
+++ b/locale/nl-NL/intents/what.time.will.it.be.intent
@@ -16,10 +16,10 @@ wanneer is het {offset} minuten vanaf nu
 wanneer is het {offset} minuten vanaf nu in {location}
 wanneer is het {offset} seconden
 wanneer is het {offset} seconden in {location} vanaf nu
-wanneer is het {offset} seconden op {locatie}
+wanneer is het {offset} seconden op {location}
 wanneer is het {offset} seconden op {location}
 wanneer is het {offset} seconden vanaf nu
-wanneer is het {offset} seconden vanaf nu in {locatie}
+wanneer is het {offset} seconden vanaf nu in {location}
 wanneer is het {offset} seconden vanaf nu in {location}
 wanneer is het {offset} uur
 wanneer is het {offset} uur in {location}

--- a/locale/pl-PL/intents/what.time.will.it.be.intent
+++ b/locale/pl-PL/intents/what.time.will.it.be.intent
@@ -142,66 +142,42 @@ godziny od teraz która jest czas we {location}
 godziny od teraz która jest godzina
 godziny od teraz która jest godzina w {location}
 godziny od teraz która jest godzina we {location}
-jaka będzie czas  godzin
-jaka będzie czas  godzin od teraz
-jaka będzie czas  godzin od teraz w {location}
-jaka będzie czas  godzin od teraz we {location}
-jaka będzie czas  godzin w {location}
-jaka będzie czas  godzin we {location}
-jaka będzie czas  godziny
-jaka będzie czas  godziny od teraz
-jaka będzie czas  godziny od teraz w {location}
-jaka będzie czas  godziny od teraz we {location}
-jaka będzie czas  godziny w {location}
-jaka będzie czas  godziny we {location}
-jaka będzie czas  minut
-jaka będzie czas  minut od teraz
-jaka będzie czas  minut od teraz w {location}
-jaka będzie czas  minut od teraz we {location}
-jaka będzie czas  minut w {location}
-jaka będzie czas  minut we {location}
-jaka będzie czas  minuty
-jaka będzie czas  minuty od teraz
-jaka będzie czas  minuty od teraz w {location}
-jaka będzie czas  minuty od teraz we {location}
-jaka będzie czas  minuty w {location}
-jaka będzie czas  minuty we {location}
-jaka będzie czas  sekund
-jaka będzie czas  sekund od teraz
-jaka będzie czas  sekund od teraz w {location}
-jaka będzie czas  sekund od teraz we {location}
-jaka będzie czas  sekund w {location}
-jaka będzie czas  sekund we {location}
-jaka będzie czas  sekundy
-jaka będzie czas  sekundy od teraz
-jaka będzie czas  sekundy od teraz w {location}
-jaka będzie czas  sekundy od teraz we {location}
-jaka będzie czas  sekundy w {location}
-jaka będzie czas  sekundy we {location}
-jaka będzie czas w {location}  godzin
-jaka będzie czas w {location}  godzin od teraz
-jaka będzie czas w {location}  godziny
-jaka będzie czas w {location}  godziny od teraz
-jaka będzie czas w {location}  minut
-jaka będzie czas w {location}  minut od teraz
-jaka będzie czas w {location}  minuty
-jaka będzie czas w {location}  minuty od teraz
-jaka będzie czas w {location}  sekund
-jaka będzie czas w {location}  sekund od teraz
-jaka będzie czas w {location}  sekundy
-jaka będzie czas w {location}  sekundy od teraz
-jaka będzie czas w {location}  {offset} godzin
-jaka będzie czas w {location}  {offset} godzin od teraz
-jaka będzie czas w {location}  {offset} godziny
-jaka będzie czas w {location}  {offset} godziny od teraz
-jaka będzie czas w {location}  {offset} minut
-jaka będzie czas w {location}  {offset} minut od teraz
-jaka będzie czas w {location}  {offset} minuty
-jaka będzie czas w {location}  {offset} minuty od teraz
-jaka będzie czas w {location}  {offset} sekund
-jaka będzie czas w {location}  {offset} sekund od teraz
-jaka będzie czas w {location}  {offset} sekundy
-jaka będzie czas w {location}  {offset} sekundy od teraz
+jaka będzie czas za {offset} godzin
+jaka będzie czas za {offset} godzin od teraz
+jaka będzie czas za {offset} godzin od teraz w {location}
+jaka będzie czas za {offset} godzin od teraz we {location}
+jaka będzie czas za {offset} godzin w {location}
+jaka będzie czas za {offset} godzin we {location}
+jaka będzie czas za {offset} godziny
+jaka będzie czas za {offset} godziny od teraz
+jaka będzie czas za {offset} godziny od teraz w {location}
+jaka będzie czas za {offset} godziny od teraz we {location}
+jaka będzie czas za {offset} godziny w {location}
+jaka będzie czas za {offset} godziny we {location}
+jaka będzie czas za {offset} minut
+jaka będzie czas za {offset} minut od teraz
+jaka będzie czas za {offset} minut od teraz w {location}
+jaka będzie czas za {offset} minut od teraz we {location}
+jaka będzie czas za {offset} minut w {location}
+jaka będzie czas za {offset} minut we {location}
+jaka będzie czas za {offset} minuty
+jaka będzie czas za {offset} minuty od teraz
+jaka będzie czas za {offset} minuty od teraz w {location}
+jaka będzie czas za {offset} minuty od teraz we {location}
+jaka będzie czas za {offset} minuty w {location}
+jaka będzie czas za {offset} minuty we {location}
+jaka będzie czas za {offset} sekund
+jaka będzie czas za {offset} sekund od teraz
+jaka będzie czas za {offset} sekund od teraz w {location}
+jaka będzie czas za {offset} sekund od teraz we {location}
+jaka będzie czas za {offset} sekund w {location}
+jaka będzie czas za {offset} sekund we {location}
+jaka będzie czas za {offset} sekundy
+jaka będzie czas za {offset} sekundy od teraz
+jaka będzie czas za {offset} sekundy od teraz w {location}
+jaka będzie czas za {offset} sekundy od teraz we {location}
+jaka będzie czas za {offset} sekundy w {location}
+jaka będzie czas za {offset} sekundy we {location}
 jaka będzie czas w {location} za {offset} godzin
 jaka będzie czas w {location} za {offset} godzin od teraz
 jaka będzie czas w {location} za {offset} godziny
@@ -214,30 +190,30 @@ jaka będzie czas w {location} za {offset} sekund
 jaka będzie czas w {location} za {offset} sekund od teraz
 jaka będzie czas w {location} za {offset} sekundy
 jaka będzie czas w {location} za {offset} sekundy od teraz
-jaka będzie czas we {location}  godzin
-jaka będzie czas we {location}  godzin od teraz
-jaka będzie czas we {location}  godziny
-jaka będzie czas we {location}  godziny od teraz
-jaka będzie czas we {location}  minut
-jaka będzie czas we {location}  minut od teraz
-jaka będzie czas we {location}  minuty
-jaka będzie czas we {location}  minuty od teraz
-jaka będzie czas we {location}  sekund
-jaka będzie czas we {location}  sekund od teraz
-jaka będzie czas we {location}  sekundy
-jaka będzie czas we {location}  sekundy od teraz
-jaka będzie czas we {location}  {offset} godzin
-jaka będzie czas we {location}  {offset} godzin od teraz
-jaka będzie czas we {location}  {offset} godziny
-jaka będzie czas we {location}  {offset} godziny od teraz
-jaka będzie czas we {location}  {offset} minut
-jaka będzie czas we {location}  {offset} minut od teraz
-jaka będzie czas we {location}  {offset} minuty
-jaka będzie czas we {location}  {offset} minuty od teraz
-jaka będzie czas we {location}  {offset} sekund
-jaka będzie czas we {location}  {offset} sekund od teraz
-jaka będzie czas we {location}  {offset} sekundy
-jaka będzie czas we {location}  {offset} sekundy od teraz
+jaka będzie czas w {location} za {offset} godzin
+jaka będzie czas w {location} za {offset} godzin od teraz
+jaka będzie czas w {location} za {offset} godziny
+jaka będzie czas w {location} za {offset} godziny od teraz
+jaka będzie czas w {location} za {offset} minut
+jaka będzie czas w {location} za {offset} minut od teraz
+jaka będzie czas w {location} za {offset} minuty
+jaka będzie czas w {location} za {offset} minuty od teraz
+jaka będzie czas w {location} za {offset} sekund
+jaka będzie czas w {location} za {offset} sekund od teraz
+jaka będzie czas w {location} za {offset} sekundy
+jaka będzie czas w {location} za {offset} sekundy od teraz
+jaka będzie czas we {location} za {offset} godzin
+jaka będzie czas we {location} za {offset} godzin od teraz
+jaka będzie czas we {location} za {offset} godziny
+jaka będzie czas we {location} za {offset} godziny od teraz
+jaka będzie czas we {location} za {offset} minut
+jaka będzie czas we {location} za {offset} minut od teraz
+jaka będzie czas we {location} za {offset} minuty
+jaka będzie czas we {location} za {offset} minuty od teraz
+jaka będzie czas we {location} za {offset} sekund
+jaka będzie czas we {location} za {offset} sekund od teraz
+jaka będzie czas we {location} za {offset} sekundy
+jaka będzie czas we {location} za {offset} sekundy od teraz
 jaka będzie czas we {location} za {offset} godzin
 jaka będzie czas we {location} za {offset} godzin od teraz
 jaka będzie czas we {location} za {offset} godziny
@@ -286,66 +262,42 @@ jaka będzie czas za {offset} sekundy od teraz w {location}
 jaka będzie czas za {offset} sekundy od teraz we {location}
 jaka będzie czas za {offset} sekundy w {location}
 jaka będzie czas za {offset} sekundy we {location}
-jaka będzie godzina  godzin
-jaka będzie godzina  godzin od teraz
-jaka będzie godzina  godzin od teraz w {location}
-jaka będzie godzina  godzin od teraz we {location}
-jaka będzie godzina  godzin w {location}
-jaka będzie godzina  godzin we {location}
-jaka będzie godzina  godziny
-jaka będzie godzina  godziny od teraz
-jaka będzie godzina  godziny od teraz w {location}
-jaka będzie godzina  godziny od teraz we {location}
-jaka będzie godzina  godziny w {location}
-jaka będzie godzina  godziny we {location}
-jaka będzie godzina  minut
-jaka będzie godzina  minut od teraz
-jaka będzie godzina  minut od teraz w {location}
-jaka będzie godzina  minut od teraz we {location}
-jaka będzie godzina  minut w {location}
-jaka będzie godzina  minut we {location}
-jaka będzie godzina  minuty
-jaka będzie godzina  minuty od teraz
-jaka będzie godzina  minuty od teraz w {location}
-jaka będzie godzina  minuty od teraz we {location}
-jaka będzie godzina  minuty w {location}
-jaka będzie godzina  minuty we {location}
-jaka będzie godzina  sekund
-jaka będzie godzina  sekund od teraz
-jaka będzie godzina  sekund od teraz w {location}
-jaka będzie godzina  sekund od teraz we {location}
-jaka będzie godzina  sekund w {location}
-jaka będzie godzina  sekund we {location}
-jaka będzie godzina  sekundy
-jaka będzie godzina  sekundy od teraz
-jaka będzie godzina  sekundy od teraz w {location}
-jaka będzie godzina  sekundy od teraz we {location}
-jaka będzie godzina  sekundy w {location}
-jaka będzie godzina  sekundy we {location}
-jaka będzie godzina w {location}  godzin
-jaka będzie godzina w {location}  godzin od teraz
-jaka będzie godzina w {location}  godziny
-jaka będzie godzina w {location}  godziny od teraz
-jaka będzie godzina w {location}  minut
-jaka będzie godzina w {location}  minut od teraz
-jaka będzie godzina w {location}  minuty
-jaka będzie godzina w {location}  minuty od teraz
-jaka będzie godzina w {location}  sekund
-jaka będzie godzina w {location}  sekund od teraz
-jaka będzie godzina w {location}  sekundy
-jaka będzie godzina w {location}  sekundy od teraz
-jaka będzie godzina w {location}  {offset} godzin
-jaka będzie godzina w {location}  {offset} godzin od teraz
-jaka będzie godzina w {location}  {offset} godziny
-jaka będzie godzina w {location}  {offset} godziny od teraz
-jaka będzie godzina w {location}  {offset} minut
-jaka będzie godzina w {location}  {offset} minut od teraz
-jaka będzie godzina w {location}  {offset} minuty
-jaka będzie godzina w {location}  {offset} minuty od teraz
-jaka będzie godzina w {location}  {offset} sekund
-jaka będzie godzina w {location}  {offset} sekund od teraz
-jaka będzie godzina w {location}  {offset} sekundy
-jaka będzie godzina w {location}  {offset} sekundy od teraz
+jaka będzie godzina za {offset} godzin
+jaka będzie godzina za {offset} godzin od teraz
+jaka będzie godzina za {offset} godzin od teraz w {location}
+jaka będzie godzina za {offset} godzin od teraz we {location}
+jaka będzie godzina za {offset} godzin w {location}
+jaka będzie godzina za {offset} godzin we {location}
+jaka będzie godzina za {offset} godziny
+jaka będzie godzina za {offset} godziny od teraz
+jaka będzie godzina za {offset} godziny od teraz w {location}
+jaka będzie godzina za {offset} godziny od teraz we {location}
+jaka będzie godzina za {offset} godziny w {location}
+jaka będzie godzina za {offset} godziny we {location}
+jaka będzie godzina za {offset} minut
+jaka będzie godzina za {offset} minut od teraz
+jaka będzie godzina za {offset} minut od teraz w {location}
+jaka będzie godzina za {offset} minut od teraz we {location}
+jaka będzie godzina za {offset} minut w {location}
+jaka będzie godzina za {offset} minut we {location}
+jaka będzie godzina za {offset} minuty
+jaka będzie godzina za {offset} minuty od teraz
+jaka będzie godzina za {offset} minuty od teraz w {location}
+jaka będzie godzina za {offset} minuty od teraz we {location}
+jaka będzie godzina za {offset} minuty w {location}
+jaka będzie godzina za {offset} minuty we {location}
+jaka będzie godzina za {offset} sekund
+jaka będzie godzina za {offset} sekund od teraz
+jaka będzie godzina za {offset} sekund od teraz w {location}
+jaka będzie godzina za {offset} sekund od teraz we {location}
+jaka będzie godzina za {offset} sekund w {location}
+jaka będzie godzina za {offset} sekund we {location}
+jaka będzie godzina za {offset} sekundy
+jaka będzie godzina za {offset} sekundy od teraz
+jaka będzie godzina za {offset} sekundy od teraz w {location}
+jaka będzie godzina za {offset} sekundy od teraz we {location}
+jaka będzie godzina za {offset} sekundy w {location}
+jaka będzie godzina za {offset} sekundy we {location}
 jaka będzie godzina w {location} za {offset} godzin
 jaka będzie godzina w {location} za {offset} godzin od teraz
 jaka będzie godzina w {location} za {offset} godziny
@@ -358,30 +310,30 @@ jaka będzie godzina w {location} za {offset} sekund
 jaka będzie godzina w {location} za {offset} sekund od teraz
 jaka będzie godzina w {location} za {offset} sekundy
 jaka będzie godzina w {location} za {offset} sekundy od teraz
-jaka będzie godzina we {location}  godzin
-jaka będzie godzina we {location}  godzin od teraz
-jaka będzie godzina we {location}  godziny
-jaka będzie godzina we {location}  godziny od teraz
-jaka będzie godzina we {location}  minut
-jaka będzie godzina we {location}  minut od teraz
-jaka będzie godzina we {location}  minuty
-jaka będzie godzina we {location}  minuty od teraz
-jaka będzie godzina we {location}  sekund
-jaka będzie godzina we {location}  sekund od teraz
-jaka będzie godzina we {location}  sekundy
-jaka będzie godzina we {location}  sekundy od teraz
-jaka będzie godzina we {location}  {offset} godzin
-jaka będzie godzina we {location}  {offset} godzin od teraz
-jaka będzie godzina we {location}  {offset} godziny
-jaka będzie godzina we {location}  {offset} godziny od teraz
-jaka będzie godzina we {location}  {offset} minut
-jaka będzie godzina we {location}  {offset} minut od teraz
-jaka będzie godzina we {location}  {offset} minuty
-jaka będzie godzina we {location}  {offset} minuty od teraz
-jaka będzie godzina we {location}  {offset} sekund
-jaka będzie godzina we {location}  {offset} sekund od teraz
-jaka będzie godzina we {location}  {offset} sekundy
-jaka będzie godzina we {location}  {offset} sekundy od teraz
+jaka będzie godzina w {location} za {offset} godzin
+jaka będzie godzina w {location} za {offset} godzin od teraz
+jaka będzie godzina w {location} za {offset} godziny
+jaka będzie godzina w {location} za {offset} godziny od teraz
+jaka będzie godzina w {location} za {offset} minut
+jaka będzie godzina w {location} za {offset} minut od teraz
+jaka będzie godzina w {location} za {offset} minuty
+jaka będzie godzina w {location} za {offset} minuty od teraz
+jaka będzie godzina w {location} za {offset} sekund
+jaka będzie godzina w {location} za {offset} sekund od teraz
+jaka będzie godzina w {location} za {offset} sekundy
+jaka będzie godzina w {location} za {offset} sekundy od teraz
+jaka będzie godzina we {location} za {offset} godzin
+jaka będzie godzina we {location} za {offset} godzin od teraz
+jaka będzie godzina we {location} za {offset} godziny
+jaka będzie godzina we {location} za {offset} godziny od teraz
+jaka będzie godzina we {location} za {offset} minut
+jaka będzie godzina we {location} za {offset} minut od teraz
+jaka będzie godzina we {location} za {offset} minuty
+jaka będzie godzina we {location} za {offset} minuty od teraz
+jaka będzie godzina we {location} za {offset} sekund
+jaka będzie godzina we {location} za {offset} sekund od teraz
+jaka będzie godzina we {location} za {offset} sekundy
+jaka będzie godzina we {location} za {offset} sekundy od teraz
 jaka będzie godzina we {location} za {offset} godzin
 jaka będzie godzina we {location} za {offset} godzin od teraz
 jaka będzie godzina we {location} za {offset} godziny
@@ -430,42 +382,6 @@ jaka będzie godzina za {offset} sekundy od teraz w {location}
 jaka będzie godzina za {offset} sekundy od teraz we {location}
 jaka będzie godzina za {offset} sekundy w {location}
 jaka będzie godzina za {offset} sekundy we {location}
-jaka czas będzie  godzin
-jaka czas będzie  godzin od teraz
-jaka czas będzie  godzin od teraz w {location}
-jaka czas będzie  godzin od teraz we {location}
-jaka czas będzie  godzin w {location}
-jaka czas będzie  godzin we {location}
-jaka czas będzie  godziny
-jaka czas będzie  godziny od teraz
-jaka czas będzie  godziny od teraz w {location}
-jaka czas będzie  godziny od teraz we {location}
-jaka czas będzie  godziny w {location}
-jaka czas będzie  godziny we {location}
-jaka czas będzie  minut
-jaka czas będzie  minut od teraz
-jaka czas będzie  minut od teraz w {location}
-jaka czas będzie  minut od teraz we {location}
-jaka czas będzie  minut w {location}
-jaka czas będzie  minut we {location}
-jaka czas będzie  minuty
-jaka czas będzie  minuty od teraz
-jaka czas będzie  minuty od teraz w {location}
-jaka czas będzie  minuty od teraz we {location}
-jaka czas będzie  minuty w {location}
-jaka czas będzie  minuty we {location}
-jaka czas będzie  sekund
-jaka czas będzie  sekund od teraz
-jaka czas będzie  sekund od teraz w {location}
-jaka czas będzie  sekund od teraz we {location}
-jaka czas będzie  sekund w {location}
-jaka czas będzie  sekund we {location}
-jaka czas będzie  sekundy
-jaka czas będzie  sekundy od teraz
-jaka czas będzie  sekundy od teraz w {location}
-jaka czas będzie  sekundy od teraz we {location}
-jaka czas będzie  sekundy w {location}
-jaka czas będzie  sekundy we {location}
 jaka czas będzie za {offset} godzin
 jaka czas będzie za {offset} godzin od teraz
 jaka czas będzie za {offset} godzin od teraz w {location}
@@ -502,42 +418,42 @@ jaka czas będzie za {offset} sekundy od teraz w {location}
 jaka czas będzie za {offset} sekundy od teraz we {location}
 jaka czas będzie za {offset} sekundy w {location}
 jaka czas będzie za {offset} sekundy we {location}
-jaka czas jest  godzin
-jaka czas jest  godzin od teraz
-jaka czas jest  godzin od teraz w {location}
-jaka czas jest  godzin od teraz we {location}
-jaka czas jest  godzin w {location}
-jaka czas jest  godzin we {location}
-jaka czas jest  godziny
-jaka czas jest  godziny od teraz
-jaka czas jest  godziny od teraz w {location}
-jaka czas jest  godziny od teraz we {location}
-jaka czas jest  godziny w {location}
-jaka czas jest  godziny we {location}
-jaka czas jest  minut
-jaka czas jest  minut od teraz
-jaka czas jest  minut od teraz w {location}
-jaka czas jest  minut od teraz we {location}
-jaka czas jest  minut w {location}
-jaka czas jest  minut we {location}
-jaka czas jest  minuty
-jaka czas jest  minuty od teraz
-jaka czas jest  minuty od teraz w {location}
-jaka czas jest  minuty od teraz we {location}
-jaka czas jest  minuty w {location}
-jaka czas jest  minuty we {location}
-jaka czas jest  sekund
-jaka czas jest  sekund od teraz
-jaka czas jest  sekund od teraz w {location}
-jaka czas jest  sekund od teraz we {location}
-jaka czas jest  sekund w {location}
-jaka czas jest  sekund we {location}
-jaka czas jest  sekundy
-jaka czas jest  sekundy od teraz
-jaka czas jest  sekundy od teraz w {location}
-jaka czas jest  sekundy od teraz we {location}
-jaka czas jest  sekundy w {location}
-jaka czas jest  sekundy we {location}
+jaka czas będzie za {offset} godzin
+jaka czas będzie za {offset} godzin od teraz
+jaka czas będzie za {offset} godzin od teraz w {location}
+jaka czas będzie za {offset} godzin od teraz we {location}
+jaka czas będzie za {offset} godzin w {location}
+jaka czas będzie za {offset} godzin we {location}
+jaka czas będzie za {offset} godziny
+jaka czas będzie za {offset} godziny od teraz
+jaka czas będzie za {offset} godziny od teraz w {location}
+jaka czas będzie za {offset} godziny od teraz we {location}
+jaka czas będzie za {offset} godziny w {location}
+jaka czas będzie za {offset} godziny we {location}
+jaka czas będzie za {offset} minut
+jaka czas będzie za {offset} minut od teraz
+jaka czas będzie za {offset} minut od teraz w {location}
+jaka czas będzie za {offset} minut od teraz we {location}
+jaka czas będzie za {offset} minut w {location}
+jaka czas będzie za {offset} minut we {location}
+jaka czas będzie za {offset} minuty
+jaka czas będzie za {offset} minuty od teraz
+jaka czas będzie za {offset} minuty od teraz w {location}
+jaka czas będzie za {offset} minuty od teraz we {location}
+jaka czas będzie za {offset} minuty w {location}
+jaka czas będzie za {offset} minuty we {location}
+jaka czas będzie za {offset} sekund
+jaka czas będzie za {offset} sekund od teraz
+jaka czas będzie za {offset} sekund od teraz w {location}
+jaka czas będzie za {offset} sekund od teraz we {location}
+jaka czas będzie za {offset} sekund w {location}
+jaka czas będzie za {offset} sekund we {location}
+jaka czas będzie za {offset} sekundy
+jaka czas będzie za {offset} sekundy od teraz
+jaka czas będzie za {offset} sekundy od teraz w {location}
+jaka czas będzie za {offset} sekundy od teraz we {location}
+jaka czas będzie za {offset} sekundy w {location}
+jaka czas będzie za {offset} sekundy we {location}
 jaka czas jest za {offset} godzin
 jaka czas jest za {offset} godzin od teraz
 jaka czas jest za {offset} godzin od teraz w {location}
@@ -574,42 +490,42 @@ jaka czas jest za {offset} sekundy od teraz w {location}
 jaka czas jest za {offset} sekundy od teraz we {location}
 jaka czas jest za {offset} sekundy w {location}
 jaka czas jest za {offset} sekundy we {location}
-jaka godzina będzie  godzin
-jaka godzina będzie  godzin od teraz
-jaka godzina będzie  godzin od teraz w {location}
-jaka godzina będzie  godzin od teraz we {location}
-jaka godzina będzie  godzin w {location}
-jaka godzina będzie  godzin we {location}
-jaka godzina będzie  godziny
-jaka godzina będzie  godziny od teraz
-jaka godzina będzie  godziny od teraz w {location}
-jaka godzina będzie  godziny od teraz we {location}
-jaka godzina będzie  godziny w {location}
-jaka godzina będzie  godziny we {location}
-jaka godzina będzie  minut
-jaka godzina będzie  minut od teraz
-jaka godzina będzie  minut od teraz w {location}
-jaka godzina będzie  minut od teraz we {location}
-jaka godzina będzie  minut w {location}
-jaka godzina będzie  minut we {location}
-jaka godzina będzie  minuty
-jaka godzina będzie  minuty od teraz
-jaka godzina będzie  minuty od teraz w {location}
-jaka godzina będzie  minuty od teraz we {location}
-jaka godzina będzie  minuty w {location}
-jaka godzina będzie  minuty we {location}
-jaka godzina będzie  sekund
-jaka godzina będzie  sekund od teraz
-jaka godzina będzie  sekund od teraz w {location}
-jaka godzina będzie  sekund od teraz we {location}
-jaka godzina będzie  sekund w {location}
-jaka godzina będzie  sekund we {location}
-jaka godzina będzie  sekundy
-jaka godzina będzie  sekundy od teraz
-jaka godzina będzie  sekundy od teraz w {location}
-jaka godzina będzie  sekundy od teraz we {location}
-jaka godzina będzie  sekundy w {location}
-jaka godzina będzie  sekundy we {location}
+jaka czas jest za {offset} godzin
+jaka czas jest za {offset} godzin od teraz
+jaka czas jest za {offset} godzin od teraz w {location}
+jaka czas jest za {offset} godzin od teraz we {location}
+jaka czas jest za {offset} godzin w {location}
+jaka czas jest za {offset} godzin we {location}
+jaka czas jest za {offset} godziny
+jaka czas jest za {offset} godziny od teraz
+jaka czas jest za {offset} godziny od teraz w {location}
+jaka czas jest za {offset} godziny od teraz we {location}
+jaka czas jest za {offset} godziny w {location}
+jaka czas jest za {offset} godziny we {location}
+jaka czas jest za {offset} minut
+jaka czas jest za {offset} minut od teraz
+jaka czas jest za {offset} minut od teraz w {location}
+jaka czas jest za {offset} minut od teraz we {location}
+jaka czas jest za {offset} minut w {location}
+jaka czas jest za {offset} minut we {location}
+jaka czas jest za {offset} minuty
+jaka czas jest za {offset} minuty od teraz
+jaka czas jest za {offset} minuty od teraz w {location}
+jaka czas jest za {offset} minuty od teraz we {location}
+jaka czas jest za {offset} minuty w {location}
+jaka czas jest za {offset} minuty we {location}
+jaka czas jest za {offset} sekund
+jaka czas jest za {offset} sekund od teraz
+jaka czas jest za {offset} sekund od teraz w {location}
+jaka czas jest za {offset} sekund od teraz we {location}
+jaka czas jest za {offset} sekund w {location}
+jaka czas jest za {offset} sekund we {location}
+jaka czas jest za {offset} sekundy
+jaka czas jest za {offset} sekundy od teraz
+jaka czas jest za {offset} sekundy od teraz w {location}
+jaka czas jest za {offset} sekundy od teraz we {location}
+jaka czas jest za {offset} sekundy w {location}
+jaka czas jest za {offset} sekundy we {location}
 jaka godzina będzie za {offset} godzin
 jaka godzina będzie za {offset} godzin od teraz
 jaka godzina będzie za {offset} godzin od teraz w {location}
@@ -646,42 +562,42 @@ jaka godzina będzie za {offset} sekundy od teraz w {location}
 jaka godzina będzie za {offset} sekundy od teraz we {location}
 jaka godzina będzie za {offset} sekundy w {location}
 jaka godzina będzie za {offset} sekundy we {location}
-jaka godzina jest  godzin
-jaka godzina jest  godzin od teraz
-jaka godzina jest  godzin od teraz w {location}
-jaka godzina jest  godzin od teraz we {location}
-jaka godzina jest  godzin w {location}
-jaka godzina jest  godzin we {location}
-jaka godzina jest  godziny
-jaka godzina jest  godziny od teraz
-jaka godzina jest  godziny od teraz w {location}
-jaka godzina jest  godziny od teraz we {location}
-jaka godzina jest  godziny w {location}
-jaka godzina jest  godziny we {location}
-jaka godzina jest  minut
-jaka godzina jest  minut od teraz
-jaka godzina jest  minut od teraz w {location}
-jaka godzina jest  minut od teraz we {location}
-jaka godzina jest  minut w {location}
-jaka godzina jest  minut we {location}
-jaka godzina jest  minuty
-jaka godzina jest  minuty od teraz
-jaka godzina jest  minuty od teraz w {location}
-jaka godzina jest  minuty od teraz we {location}
-jaka godzina jest  minuty w {location}
-jaka godzina jest  minuty we {location}
-jaka godzina jest  sekund
-jaka godzina jest  sekund od teraz
-jaka godzina jest  sekund od teraz w {location}
-jaka godzina jest  sekund od teraz we {location}
-jaka godzina jest  sekund w {location}
-jaka godzina jest  sekund we {location}
-jaka godzina jest  sekundy
-jaka godzina jest  sekundy od teraz
-jaka godzina jest  sekundy od teraz w {location}
-jaka godzina jest  sekundy od teraz we {location}
-jaka godzina jest  sekundy w {location}
-jaka godzina jest  sekundy we {location}
+jaka godzina będzie za {offset} godzin
+jaka godzina będzie za {offset} godzin od teraz
+jaka godzina będzie za {offset} godzin od teraz w {location}
+jaka godzina będzie za {offset} godzin od teraz we {location}
+jaka godzina będzie za {offset} godzin w {location}
+jaka godzina będzie za {offset} godzin we {location}
+jaka godzina będzie za {offset} godziny
+jaka godzina będzie za {offset} godziny od teraz
+jaka godzina będzie za {offset} godziny od teraz w {location}
+jaka godzina będzie za {offset} godziny od teraz we {location}
+jaka godzina będzie za {offset} godziny w {location}
+jaka godzina będzie za {offset} godziny we {location}
+jaka godzina będzie za {offset} minut
+jaka godzina będzie za {offset} minut od teraz
+jaka godzina będzie za {offset} minut od teraz w {location}
+jaka godzina będzie za {offset} minut od teraz we {location}
+jaka godzina będzie za {offset} minut w {location}
+jaka godzina będzie za {offset} minut we {location}
+jaka godzina będzie za {offset} minuty
+jaka godzina będzie za {offset} minuty od teraz
+jaka godzina będzie za {offset} minuty od teraz w {location}
+jaka godzina będzie za {offset} minuty od teraz we {location}
+jaka godzina będzie za {offset} minuty w {location}
+jaka godzina będzie za {offset} minuty we {location}
+jaka godzina będzie za {offset} sekund
+jaka godzina będzie za {offset} sekund od teraz
+jaka godzina będzie za {offset} sekund od teraz w {location}
+jaka godzina będzie za {offset} sekund od teraz we {location}
+jaka godzina będzie za {offset} sekund w {location}
+jaka godzina będzie za {offset} sekund we {location}
+jaka godzina będzie za {offset} sekundy
+jaka godzina będzie za {offset} sekundy od teraz
+jaka godzina będzie za {offset} sekundy od teraz w {location}
+jaka godzina będzie za {offset} sekundy od teraz we {location}
+jaka godzina będzie za {offset} sekundy w {location}
+jaka godzina będzie za {offset} sekundy we {location}
 jaka godzina jest za {offset} godzin
 jaka godzina jest za {offset} godzin od teraz
 jaka godzina jest za {offset} godzin od teraz w {location}
@@ -718,66 +634,78 @@ jaka godzina jest za {offset} sekundy od teraz w {location}
 jaka godzina jest za {offset} sekundy od teraz we {location}
 jaka godzina jest za {offset} sekundy w {location}
 jaka godzina jest za {offset} sekundy we {location}
-jaka jest czas  godzin
-jaka jest czas  godzin od teraz
-jaka jest czas  godzin od teraz w {location}
-jaka jest czas  godzin od teraz we {location}
-jaka jest czas  godzin w {location}
-jaka jest czas  godzin we {location}
-jaka jest czas  godziny
-jaka jest czas  godziny od teraz
-jaka jest czas  godziny od teraz w {location}
-jaka jest czas  godziny od teraz we {location}
-jaka jest czas  godziny w {location}
-jaka jest czas  godziny we {location}
-jaka jest czas  minut
-jaka jest czas  minut od teraz
-jaka jest czas  minut od teraz w {location}
-jaka jest czas  minut od teraz we {location}
-jaka jest czas  minut w {location}
-jaka jest czas  minut we {location}
-jaka jest czas  minuty
-jaka jest czas  minuty od teraz
-jaka jest czas  minuty od teraz w {location}
-jaka jest czas  minuty od teraz we {location}
-jaka jest czas  minuty w {location}
-jaka jest czas  minuty we {location}
-jaka jest czas  sekund
-jaka jest czas  sekund od teraz
-jaka jest czas  sekund od teraz w {location}
-jaka jest czas  sekund od teraz we {location}
-jaka jest czas  sekund w {location}
-jaka jest czas  sekund we {location}
-jaka jest czas  sekundy
-jaka jest czas  sekundy od teraz
-jaka jest czas  sekundy od teraz w {location}
-jaka jest czas  sekundy od teraz we {location}
-jaka jest czas  sekundy w {location}
-jaka jest czas  sekundy we {location}
-jaka jest czas w {location}  godzin
-jaka jest czas w {location}  godzin od teraz
-jaka jest czas w {location}  godziny
-jaka jest czas w {location}  godziny od teraz
-jaka jest czas w {location}  minut
-jaka jest czas w {location}  minut od teraz
-jaka jest czas w {location}  minuty
-jaka jest czas w {location}  minuty od teraz
-jaka jest czas w {location}  sekund
-jaka jest czas w {location}  sekund od teraz
-jaka jest czas w {location}  sekundy
-jaka jest czas w {location}  sekundy od teraz
-jaka jest czas w {location}  {offset} godzin
-jaka jest czas w {location}  {offset} godzin od teraz
-jaka jest czas w {location}  {offset} godziny
-jaka jest czas w {location}  {offset} godziny od teraz
-jaka jest czas w {location}  {offset} minut
-jaka jest czas w {location}  {offset} minut od teraz
-jaka jest czas w {location}  {offset} minuty
-jaka jest czas w {location}  {offset} minuty od teraz
-jaka jest czas w {location}  {offset} sekund
-jaka jest czas w {location}  {offset} sekund od teraz
-jaka jest czas w {location}  {offset} sekundy
-jaka jest czas w {location}  {offset} sekundy od teraz
+jaka godzina jest za {offset} godzin
+jaka godzina jest za {offset} godzin od teraz
+jaka godzina jest za {offset} godzin od teraz w {location}
+jaka godzina jest za {offset} godzin od teraz we {location}
+jaka godzina jest za {offset} godzin w {location}
+jaka godzina jest za {offset} godzin we {location}
+jaka godzina jest za {offset} godziny
+jaka godzina jest za {offset} godziny od teraz
+jaka godzina jest za {offset} godziny od teraz w {location}
+jaka godzina jest za {offset} godziny od teraz we {location}
+jaka godzina jest za {offset} godziny w {location}
+jaka godzina jest za {offset} godziny we {location}
+jaka godzina jest za {offset} minut
+jaka godzina jest za {offset} minut od teraz
+jaka godzina jest za {offset} minut od teraz w {location}
+jaka godzina jest za {offset} minut od teraz we {location}
+jaka godzina jest za {offset} minut w {location}
+jaka godzina jest za {offset} minut we {location}
+jaka godzina jest za {offset} minuty
+jaka godzina jest za {offset} minuty od teraz
+jaka godzina jest za {offset} minuty od teraz w {location}
+jaka godzina jest za {offset} minuty od teraz we {location}
+jaka godzina jest za {offset} minuty w {location}
+jaka godzina jest za {offset} minuty we {location}
+jaka godzina jest za {offset} sekund
+jaka godzina jest za {offset} sekund od teraz
+jaka godzina jest za {offset} sekund od teraz w {location}
+jaka godzina jest za {offset} sekund od teraz we {location}
+jaka godzina jest za {offset} sekund w {location}
+jaka godzina jest za {offset} sekund we {location}
+jaka godzina jest za {offset} sekundy
+jaka godzina jest za {offset} sekundy od teraz
+jaka godzina jest za {offset} sekundy od teraz w {location}
+jaka godzina jest za {offset} sekundy od teraz we {location}
+jaka godzina jest za {offset} sekundy w {location}
+jaka godzina jest za {offset} sekundy we {location}
+jaka jest czas za {offset} godzin
+jaka jest czas za {offset} godzin od teraz
+jaka jest czas za {offset} godzin od teraz w {location}
+jaka jest czas za {offset} godzin od teraz we {location}
+jaka jest czas za {offset} godzin w {location}
+jaka jest czas za {offset} godzin we {location}
+jaka jest czas za {offset} godziny
+jaka jest czas za {offset} godziny od teraz
+jaka jest czas za {offset} godziny od teraz w {location}
+jaka jest czas za {offset} godziny od teraz we {location}
+jaka jest czas za {offset} godziny w {location}
+jaka jest czas za {offset} godziny we {location}
+jaka jest czas za {offset} minut
+jaka jest czas za {offset} minut od teraz
+jaka jest czas za {offset} minut od teraz w {location}
+jaka jest czas za {offset} minut od teraz we {location}
+jaka jest czas za {offset} minut w {location}
+jaka jest czas za {offset} minut we {location}
+jaka jest czas za {offset} minuty
+jaka jest czas za {offset} minuty od teraz
+jaka jest czas za {offset} minuty od teraz w {location}
+jaka jest czas za {offset} minuty od teraz we {location}
+jaka jest czas za {offset} minuty w {location}
+jaka jest czas za {offset} minuty we {location}
+jaka jest czas za {offset} sekund
+jaka jest czas za {offset} sekund od teraz
+jaka jest czas za {offset} sekund od teraz w {location}
+jaka jest czas za {offset} sekund od teraz we {location}
+jaka jest czas za {offset} sekund w {location}
+jaka jest czas za {offset} sekund we {location}
+jaka jest czas za {offset} sekundy
+jaka jest czas za {offset} sekundy od teraz
+jaka jest czas za {offset} sekundy od teraz w {location}
+jaka jest czas za {offset} sekundy od teraz we {location}
+jaka jest czas za {offset} sekundy w {location}
+jaka jest czas za {offset} sekundy we {location}
 jaka jest czas w {location} za {offset} godzin
 jaka jest czas w {location} za {offset} godzin od teraz
 jaka jest czas w {location} za {offset} godziny
@@ -790,30 +718,30 @@ jaka jest czas w {location} za {offset} sekund
 jaka jest czas w {location} za {offset} sekund od teraz
 jaka jest czas w {location} za {offset} sekundy
 jaka jest czas w {location} za {offset} sekundy od teraz
-jaka jest czas we {location}  godzin
-jaka jest czas we {location}  godzin od teraz
-jaka jest czas we {location}  godziny
-jaka jest czas we {location}  godziny od teraz
-jaka jest czas we {location}  minut
-jaka jest czas we {location}  minut od teraz
-jaka jest czas we {location}  minuty
-jaka jest czas we {location}  minuty od teraz
-jaka jest czas we {location}  sekund
-jaka jest czas we {location}  sekund od teraz
-jaka jest czas we {location}  sekundy
-jaka jest czas we {location}  sekundy od teraz
-jaka jest czas we {location}  {offset} godzin
-jaka jest czas we {location}  {offset} godzin od teraz
-jaka jest czas we {location}  {offset} godziny
-jaka jest czas we {location}  {offset} godziny od teraz
-jaka jest czas we {location}  {offset} minut
-jaka jest czas we {location}  {offset} minut od teraz
-jaka jest czas we {location}  {offset} minuty
-jaka jest czas we {location}  {offset} minuty od teraz
-jaka jest czas we {location}  {offset} sekund
-jaka jest czas we {location}  {offset} sekund od teraz
-jaka jest czas we {location}  {offset} sekundy
-jaka jest czas we {location}  {offset} sekundy od teraz
+jaka jest czas w {location} za {offset} godzin
+jaka jest czas w {location} za {offset} godzin od teraz
+jaka jest czas w {location} za {offset} godziny
+jaka jest czas w {location} za {offset} godziny od teraz
+jaka jest czas w {location} za {offset} minut
+jaka jest czas w {location} za {offset} minut od teraz
+jaka jest czas w {location} za {offset} minuty
+jaka jest czas w {location} za {offset} minuty od teraz
+jaka jest czas w {location} za {offset} sekund
+jaka jest czas w {location} za {offset} sekund od teraz
+jaka jest czas w {location} za {offset} sekundy
+jaka jest czas w {location} za {offset} sekundy od teraz
+jaka jest czas we {location} za {offset} godzin
+jaka jest czas we {location} za {offset} godzin od teraz
+jaka jest czas we {location} za {offset} godziny
+jaka jest czas we {location} za {offset} godziny od teraz
+jaka jest czas we {location} za {offset} minut
+jaka jest czas we {location} za {offset} minut od teraz
+jaka jest czas we {location} za {offset} minuty
+jaka jest czas we {location} za {offset} minuty od teraz
+jaka jest czas we {location} za {offset} sekund
+jaka jest czas we {location} za {offset} sekund od teraz
+jaka jest czas we {location} za {offset} sekundy
+jaka jest czas we {location} za {offset} sekundy od teraz
 jaka jest czas we {location} za {offset} godzin
 jaka jest czas we {location} za {offset} godzin od teraz
 jaka jest czas we {location} za {offset} godziny
@@ -862,66 +790,42 @@ jaka jest czas za {offset} sekundy od teraz w {location}
 jaka jest czas za {offset} sekundy od teraz we {location}
 jaka jest czas za {offset} sekundy w {location}
 jaka jest czas za {offset} sekundy we {location}
-jaka jest godzina  godzin
-jaka jest godzina  godzin od teraz
-jaka jest godzina  godzin od teraz w {location}
-jaka jest godzina  godzin od teraz we {location}
-jaka jest godzina  godzin w {location}
-jaka jest godzina  godzin we {location}
-jaka jest godzina  godziny
-jaka jest godzina  godziny od teraz
-jaka jest godzina  godziny od teraz w {location}
-jaka jest godzina  godziny od teraz we {location}
-jaka jest godzina  godziny w {location}
-jaka jest godzina  godziny we {location}
-jaka jest godzina  minut
-jaka jest godzina  minut od teraz
-jaka jest godzina  minut od teraz w {location}
-jaka jest godzina  minut od teraz we {location}
-jaka jest godzina  minut w {location}
-jaka jest godzina  minut we {location}
-jaka jest godzina  minuty
-jaka jest godzina  minuty od teraz
-jaka jest godzina  minuty od teraz w {location}
-jaka jest godzina  minuty od teraz we {location}
-jaka jest godzina  minuty w {location}
-jaka jest godzina  minuty we {location}
-jaka jest godzina  sekund
-jaka jest godzina  sekund od teraz
-jaka jest godzina  sekund od teraz w {location}
-jaka jest godzina  sekund od teraz we {location}
-jaka jest godzina  sekund w {location}
-jaka jest godzina  sekund we {location}
-jaka jest godzina  sekundy
-jaka jest godzina  sekundy od teraz
-jaka jest godzina  sekundy od teraz w {location}
-jaka jest godzina  sekundy od teraz we {location}
-jaka jest godzina  sekundy w {location}
-jaka jest godzina  sekundy we {location}
-jaka jest godzina w {location}  godzin
-jaka jest godzina w {location}  godzin od teraz
-jaka jest godzina w {location}  godziny
-jaka jest godzina w {location}  godziny od teraz
-jaka jest godzina w {location}  minut
-jaka jest godzina w {location}  minut od teraz
-jaka jest godzina w {location}  minuty
-jaka jest godzina w {location}  minuty od teraz
-jaka jest godzina w {location}  sekund
-jaka jest godzina w {location}  sekund od teraz
-jaka jest godzina w {location}  sekundy
-jaka jest godzina w {location}  sekundy od teraz
-jaka jest godzina w {location}  {offset} godzin
-jaka jest godzina w {location}  {offset} godzin od teraz
-jaka jest godzina w {location}  {offset} godziny
-jaka jest godzina w {location}  {offset} godziny od teraz
-jaka jest godzina w {location}  {offset} minut
-jaka jest godzina w {location}  {offset} minut od teraz
-jaka jest godzina w {location}  {offset} minuty
-jaka jest godzina w {location}  {offset} minuty od teraz
-jaka jest godzina w {location}  {offset} sekund
-jaka jest godzina w {location}  {offset} sekund od teraz
-jaka jest godzina w {location}  {offset} sekundy
-jaka jest godzina w {location}  {offset} sekundy od teraz
+jaka jest godzina za {offset} godzin
+jaka jest godzina za {offset} godzin od teraz
+jaka jest godzina za {offset} godzin od teraz w {location}
+jaka jest godzina za {offset} godzin od teraz we {location}
+jaka jest godzina za {offset} godzin w {location}
+jaka jest godzina za {offset} godzin we {location}
+jaka jest godzina za {offset} godziny
+jaka jest godzina za {offset} godziny od teraz
+jaka jest godzina za {offset} godziny od teraz w {location}
+jaka jest godzina za {offset} godziny od teraz we {location}
+jaka jest godzina za {offset} godziny w {location}
+jaka jest godzina za {offset} godziny we {location}
+jaka jest godzina za {offset} minut
+jaka jest godzina za {offset} minut od teraz
+jaka jest godzina za {offset} minut od teraz w {location}
+jaka jest godzina za {offset} minut od teraz we {location}
+jaka jest godzina za {offset} minut w {location}
+jaka jest godzina za {offset} minut we {location}
+jaka jest godzina za {offset} minuty
+jaka jest godzina za {offset} minuty od teraz
+jaka jest godzina za {offset} minuty od teraz w {location}
+jaka jest godzina za {offset} minuty od teraz we {location}
+jaka jest godzina za {offset} minuty w {location}
+jaka jest godzina za {offset} minuty we {location}
+jaka jest godzina za {offset} sekund
+jaka jest godzina za {offset} sekund od teraz
+jaka jest godzina za {offset} sekund od teraz w {location}
+jaka jest godzina za {offset} sekund od teraz we {location}
+jaka jest godzina za {offset} sekund w {location}
+jaka jest godzina za {offset} sekund we {location}
+jaka jest godzina za {offset} sekundy
+jaka jest godzina za {offset} sekundy od teraz
+jaka jest godzina za {offset} sekundy od teraz w {location}
+jaka jest godzina za {offset} sekundy od teraz we {location}
+jaka jest godzina za {offset} sekundy w {location}
+jaka jest godzina za {offset} sekundy we {location}
 jaka jest godzina w {location} za {offset} godzin
 jaka jest godzina w {location} za {offset} godzin od teraz
 jaka jest godzina w {location} za {offset} godziny
@@ -934,30 +838,30 @@ jaka jest godzina w {location} za {offset} sekund
 jaka jest godzina w {location} za {offset} sekund od teraz
 jaka jest godzina w {location} za {offset} sekundy
 jaka jest godzina w {location} za {offset} sekundy od teraz
-jaka jest godzina we {location}  godzin
-jaka jest godzina we {location}  godzin od teraz
-jaka jest godzina we {location}  godziny
-jaka jest godzina we {location}  godziny od teraz
-jaka jest godzina we {location}  minut
-jaka jest godzina we {location}  minut od teraz
-jaka jest godzina we {location}  minuty
-jaka jest godzina we {location}  minuty od teraz
-jaka jest godzina we {location}  sekund
-jaka jest godzina we {location}  sekund od teraz
-jaka jest godzina we {location}  sekundy
-jaka jest godzina we {location}  sekundy od teraz
-jaka jest godzina we {location}  {offset} godzin
-jaka jest godzina we {location}  {offset} godzin od teraz
-jaka jest godzina we {location}  {offset} godziny
-jaka jest godzina we {location}  {offset} godziny od teraz
-jaka jest godzina we {location}  {offset} minut
-jaka jest godzina we {location}  {offset} minut od teraz
-jaka jest godzina we {location}  {offset} minuty
-jaka jest godzina we {location}  {offset} minuty od teraz
-jaka jest godzina we {location}  {offset} sekund
-jaka jest godzina we {location}  {offset} sekund od teraz
-jaka jest godzina we {location}  {offset} sekundy
-jaka jest godzina we {location}  {offset} sekundy od teraz
+jaka jest godzina w {location} za {offset} godzin
+jaka jest godzina w {location} za {offset} godzin od teraz
+jaka jest godzina w {location} za {offset} godziny
+jaka jest godzina w {location} za {offset} godziny od teraz
+jaka jest godzina w {location} za {offset} minut
+jaka jest godzina w {location} za {offset} minut od teraz
+jaka jest godzina w {location} za {offset} minuty
+jaka jest godzina w {location} za {offset} minuty od teraz
+jaka jest godzina w {location} za {offset} sekund
+jaka jest godzina w {location} za {offset} sekund od teraz
+jaka jest godzina w {location} za {offset} sekundy
+jaka jest godzina w {location} za {offset} sekundy od teraz
+jaka jest godzina we {location} za {offset} godzin
+jaka jest godzina we {location} za {offset} godzin od teraz
+jaka jest godzina we {location} za {offset} godziny
+jaka jest godzina we {location} za {offset} godziny od teraz
+jaka jest godzina we {location} za {offset} minut
+jaka jest godzina we {location} za {offset} minut od teraz
+jaka jest godzina we {location} za {offset} minuty
+jaka jest godzina we {location} za {offset} minuty od teraz
+jaka jest godzina we {location} za {offset} sekund
+jaka jest godzina we {location} za {offset} sekund od teraz
+jaka jest godzina we {location} za {offset} sekundy
+jaka jest godzina we {location} za {offset} sekundy od teraz
 jaka jest godzina we {location} za {offset} godzin
 jaka jest godzina we {location} za {offset} godzin od teraz
 jaka jest godzina we {location} za {offset} godziny
@@ -1006,66 +910,42 @@ jaka jest godzina za {offset} sekundy od teraz w {location}
 jaka jest godzina za {offset} sekundy od teraz we {location}
 jaka jest godzina za {offset} sekundy w {location}
 jaka jest godzina za {offset} sekundy we {location}
-jaki będzie czas  godzin
-jaki będzie czas  godzin od teraz
-jaki będzie czas  godzin od teraz w {location}
-jaki będzie czas  godzin od teraz we {location}
-jaki będzie czas  godzin w {location}
-jaki będzie czas  godzin we {location}
-jaki będzie czas  godziny
-jaki będzie czas  godziny od teraz
-jaki będzie czas  godziny od teraz w {location}
-jaki będzie czas  godziny od teraz we {location}
-jaki będzie czas  godziny w {location}
-jaki będzie czas  godziny we {location}
-jaki będzie czas  minut
-jaki będzie czas  minut od teraz
-jaki będzie czas  minut od teraz w {location}
-jaki będzie czas  minut od teraz we {location}
-jaki będzie czas  minut w {location}
-jaki będzie czas  minut we {location}
-jaki będzie czas  minuty
-jaki będzie czas  minuty od teraz
-jaki będzie czas  minuty od teraz w {location}
-jaki będzie czas  minuty od teraz we {location}
-jaki będzie czas  minuty w {location}
-jaki będzie czas  minuty we {location}
-jaki będzie czas  sekund
-jaki będzie czas  sekund od teraz
-jaki będzie czas  sekund od teraz w {location}
-jaki będzie czas  sekund od teraz we {location}
-jaki będzie czas  sekund w {location}
-jaki będzie czas  sekund we {location}
-jaki będzie czas  sekundy
-jaki będzie czas  sekundy od teraz
-jaki będzie czas  sekundy od teraz w {location}
-jaki będzie czas  sekundy od teraz we {location}
-jaki będzie czas  sekundy w {location}
-jaki będzie czas  sekundy we {location}
-jaki będzie czas w {location}  godzin
-jaki będzie czas w {location}  godzin od teraz
-jaki będzie czas w {location}  godziny
-jaki będzie czas w {location}  godziny od teraz
-jaki będzie czas w {location}  minut
-jaki będzie czas w {location}  minut od teraz
-jaki będzie czas w {location}  minuty
-jaki będzie czas w {location}  minuty od teraz
-jaki będzie czas w {location}  sekund
-jaki będzie czas w {location}  sekund od teraz
-jaki będzie czas w {location}  sekundy
-jaki będzie czas w {location}  sekundy od teraz
-jaki będzie czas w {location}  {offset} godzin
-jaki będzie czas w {location}  {offset} godzin od teraz
-jaki będzie czas w {location}  {offset} godziny
-jaki będzie czas w {location}  {offset} godziny od teraz
-jaki będzie czas w {location}  {offset} minut
-jaki będzie czas w {location}  {offset} minut od teraz
-jaki będzie czas w {location}  {offset} minuty
-jaki będzie czas w {location}  {offset} minuty od teraz
-jaki będzie czas w {location}  {offset} sekund
-jaki będzie czas w {location}  {offset} sekund od teraz
-jaki będzie czas w {location}  {offset} sekundy
-jaki będzie czas w {location}  {offset} sekundy od teraz
+jaki będzie czas za {offset} godzin
+jaki będzie czas za {offset} godzin od teraz
+jaki będzie czas za {offset} godzin od teraz w {location}
+jaki będzie czas za {offset} godzin od teraz we {location}
+jaki będzie czas za {offset} godzin w {location}
+jaki będzie czas za {offset} godzin we {location}
+jaki będzie czas za {offset} godziny
+jaki będzie czas za {offset} godziny od teraz
+jaki będzie czas za {offset} godziny od teraz w {location}
+jaki będzie czas za {offset} godziny od teraz we {location}
+jaki będzie czas za {offset} godziny w {location}
+jaki będzie czas za {offset} godziny we {location}
+jaki będzie czas za {offset} minut
+jaki będzie czas za {offset} minut od teraz
+jaki będzie czas za {offset} minut od teraz w {location}
+jaki będzie czas za {offset} minut od teraz we {location}
+jaki będzie czas za {offset} minut w {location}
+jaki będzie czas za {offset} minut we {location}
+jaki będzie czas za {offset} minuty
+jaki będzie czas za {offset} minuty od teraz
+jaki będzie czas za {offset} minuty od teraz w {location}
+jaki będzie czas za {offset} minuty od teraz we {location}
+jaki będzie czas za {offset} minuty w {location}
+jaki będzie czas za {offset} minuty we {location}
+jaki będzie czas za {offset} sekund
+jaki będzie czas za {offset} sekund od teraz
+jaki będzie czas za {offset} sekund od teraz w {location}
+jaki będzie czas za {offset} sekund od teraz we {location}
+jaki będzie czas za {offset} sekund w {location}
+jaki będzie czas za {offset} sekund we {location}
+jaki będzie czas za {offset} sekundy
+jaki będzie czas za {offset} sekundy od teraz
+jaki będzie czas za {offset} sekundy od teraz w {location}
+jaki będzie czas za {offset} sekundy od teraz we {location}
+jaki będzie czas za {offset} sekundy w {location}
+jaki będzie czas za {offset} sekundy we {location}
 jaki będzie czas w {location} za {offset} godzin
 jaki będzie czas w {location} za {offset} godzin od teraz
 jaki będzie czas w {location} za {offset} godziny
@@ -1078,30 +958,30 @@ jaki będzie czas w {location} za {offset} sekund
 jaki będzie czas w {location} za {offset} sekund od teraz
 jaki będzie czas w {location} za {offset} sekundy
 jaki będzie czas w {location} za {offset} sekundy od teraz
-jaki będzie czas we {location}  godzin
-jaki będzie czas we {location}  godzin od teraz
-jaki będzie czas we {location}  godziny
-jaki będzie czas we {location}  godziny od teraz
-jaki będzie czas we {location}  minut
-jaki będzie czas we {location}  minut od teraz
-jaki będzie czas we {location}  minuty
-jaki będzie czas we {location}  minuty od teraz
-jaki będzie czas we {location}  sekund
-jaki będzie czas we {location}  sekund od teraz
-jaki będzie czas we {location}  sekundy
-jaki będzie czas we {location}  sekundy od teraz
-jaki będzie czas we {location}  {offset} godzin
-jaki będzie czas we {location}  {offset} godzin od teraz
-jaki będzie czas we {location}  {offset} godziny
-jaki będzie czas we {location}  {offset} godziny od teraz
-jaki będzie czas we {location}  {offset} minut
-jaki będzie czas we {location}  {offset} minut od teraz
-jaki będzie czas we {location}  {offset} minuty
-jaki będzie czas we {location}  {offset} minuty od teraz
-jaki będzie czas we {location}  {offset} sekund
-jaki będzie czas we {location}  {offset} sekund od teraz
-jaki będzie czas we {location}  {offset} sekundy
-jaki będzie czas we {location}  {offset} sekundy od teraz
+jaki będzie czas w {location} za {offset} godzin
+jaki będzie czas w {location} za {offset} godzin od teraz
+jaki będzie czas w {location} za {offset} godziny
+jaki będzie czas w {location} za {offset} godziny od teraz
+jaki będzie czas w {location} za {offset} minut
+jaki będzie czas w {location} za {offset} minut od teraz
+jaki będzie czas w {location} za {offset} minuty
+jaki będzie czas w {location} za {offset} minuty od teraz
+jaki będzie czas w {location} za {offset} sekund
+jaki będzie czas w {location} za {offset} sekund od teraz
+jaki będzie czas w {location} za {offset} sekundy
+jaki będzie czas w {location} za {offset} sekundy od teraz
+jaki będzie czas we {location} za {offset} godzin
+jaki będzie czas we {location} za {offset} godzin od teraz
+jaki będzie czas we {location} za {offset} godziny
+jaki będzie czas we {location} za {offset} godziny od teraz
+jaki będzie czas we {location} za {offset} minut
+jaki będzie czas we {location} za {offset} minut od teraz
+jaki będzie czas we {location} za {offset} minuty
+jaki będzie czas we {location} za {offset} minuty od teraz
+jaki będzie czas we {location} za {offset} sekund
+jaki będzie czas we {location} za {offset} sekund od teraz
+jaki będzie czas we {location} za {offset} sekundy
+jaki będzie czas we {location} za {offset} sekundy od teraz
 jaki będzie czas we {location} za {offset} godzin
 jaki będzie czas we {location} za {offset} godzin od teraz
 jaki będzie czas we {location} za {offset} godziny
@@ -1150,66 +1030,42 @@ jaki będzie czas za {offset} sekundy od teraz w {location}
 jaki będzie czas za {offset} sekundy od teraz we {location}
 jaki będzie czas za {offset} sekundy w {location}
 jaki będzie czas za {offset} sekundy we {location}
-jaki będzie godzina  godzin
-jaki będzie godzina  godzin od teraz
-jaki będzie godzina  godzin od teraz w {location}
-jaki będzie godzina  godzin od teraz we {location}
-jaki będzie godzina  godzin w {location}
-jaki będzie godzina  godzin we {location}
-jaki będzie godzina  godziny
-jaki będzie godzina  godziny od teraz
-jaki będzie godzina  godziny od teraz w {location}
-jaki będzie godzina  godziny od teraz we {location}
-jaki będzie godzina  godziny w {location}
-jaki będzie godzina  godziny we {location}
-jaki będzie godzina  minut
-jaki będzie godzina  minut od teraz
-jaki będzie godzina  minut od teraz w {location}
-jaki będzie godzina  minut od teraz we {location}
-jaki będzie godzina  minut w {location}
-jaki będzie godzina  minut we {location}
-jaki będzie godzina  minuty
-jaki będzie godzina  minuty od teraz
-jaki będzie godzina  minuty od teraz w {location}
-jaki będzie godzina  minuty od teraz we {location}
-jaki będzie godzina  minuty w {location}
-jaki będzie godzina  minuty we {location}
-jaki będzie godzina  sekund
-jaki będzie godzina  sekund od teraz
-jaki będzie godzina  sekund od teraz w {location}
-jaki będzie godzina  sekund od teraz we {location}
-jaki będzie godzina  sekund w {location}
-jaki będzie godzina  sekund we {location}
-jaki będzie godzina  sekundy
-jaki będzie godzina  sekundy od teraz
-jaki będzie godzina  sekundy od teraz w {location}
-jaki będzie godzina  sekundy od teraz we {location}
-jaki będzie godzina  sekundy w {location}
-jaki będzie godzina  sekundy we {location}
-jaki będzie godzina w {location}  godzin
-jaki będzie godzina w {location}  godzin od teraz
-jaki będzie godzina w {location}  godziny
-jaki będzie godzina w {location}  godziny od teraz
-jaki będzie godzina w {location}  minut
-jaki będzie godzina w {location}  minut od teraz
-jaki będzie godzina w {location}  minuty
-jaki będzie godzina w {location}  minuty od teraz
-jaki będzie godzina w {location}  sekund
-jaki będzie godzina w {location}  sekund od teraz
-jaki będzie godzina w {location}  sekundy
-jaki będzie godzina w {location}  sekundy od teraz
-jaki będzie godzina w {location}  {offset} godzin
-jaki będzie godzina w {location}  {offset} godzin od teraz
-jaki będzie godzina w {location}  {offset} godziny
-jaki będzie godzina w {location}  {offset} godziny od teraz
-jaki będzie godzina w {location}  {offset} minut
-jaki będzie godzina w {location}  {offset} minut od teraz
-jaki będzie godzina w {location}  {offset} minuty
-jaki będzie godzina w {location}  {offset} minuty od teraz
-jaki będzie godzina w {location}  {offset} sekund
-jaki będzie godzina w {location}  {offset} sekund od teraz
-jaki będzie godzina w {location}  {offset} sekundy
-jaki będzie godzina w {location}  {offset} sekundy od teraz
+jaki będzie godzina za {offset} godzin
+jaki będzie godzina za {offset} godzin od teraz
+jaki będzie godzina za {offset} godzin od teraz w {location}
+jaki będzie godzina za {offset} godzin od teraz we {location}
+jaki będzie godzina za {offset} godzin w {location}
+jaki będzie godzina za {offset} godzin we {location}
+jaki będzie godzina za {offset} godziny
+jaki będzie godzina za {offset} godziny od teraz
+jaki będzie godzina za {offset} godziny od teraz w {location}
+jaki będzie godzina za {offset} godziny od teraz we {location}
+jaki będzie godzina za {offset} godziny w {location}
+jaki będzie godzina za {offset} godziny we {location}
+jaki będzie godzina za {offset} minut
+jaki będzie godzina za {offset} minut od teraz
+jaki będzie godzina za {offset} minut od teraz w {location}
+jaki będzie godzina za {offset} minut od teraz we {location}
+jaki będzie godzina za {offset} minut w {location}
+jaki będzie godzina za {offset} minut we {location}
+jaki będzie godzina za {offset} minuty
+jaki będzie godzina za {offset} minuty od teraz
+jaki będzie godzina za {offset} minuty od teraz w {location}
+jaki będzie godzina za {offset} minuty od teraz we {location}
+jaki będzie godzina za {offset} minuty w {location}
+jaki będzie godzina za {offset} minuty we {location}
+jaki będzie godzina za {offset} sekund
+jaki będzie godzina za {offset} sekund od teraz
+jaki będzie godzina za {offset} sekund od teraz w {location}
+jaki będzie godzina za {offset} sekund od teraz we {location}
+jaki będzie godzina za {offset} sekund w {location}
+jaki będzie godzina za {offset} sekund we {location}
+jaki będzie godzina za {offset} sekundy
+jaki będzie godzina za {offset} sekundy od teraz
+jaki będzie godzina za {offset} sekundy od teraz w {location}
+jaki będzie godzina za {offset} sekundy od teraz we {location}
+jaki będzie godzina za {offset} sekundy w {location}
+jaki będzie godzina za {offset} sekundy we {location}
 jaki będzie godzina w {location} za {offset} godzin
 jaki będzie godzina w {location} za {offset} godzin od teraz
 jaki będzie godzina w {location} za {offset} godziny
@@ -1222,30 +1078,30 @@ jaki będzie godzina w {location} za {offset} sekund
 jaki będzie godzina w {location} za {offset} sekund od teraz
 jaki będzie godzina w {location} za {offset} sekundy
 jaki będzie godzina w {location} za {offset} sekundy od teraz
-jaki będzie godzina we {location}  godzin
-jaki będzie godzina we {location}  godzin od teraz
-jaki będzie godzina we {location}  godziny
-jaki będzie godzina we {location}  godziny od teraz
-jaki będzie godzina we {location}  minut
-jaki będzie godzina we {location}  minut od teraz
-jaki będzie godzina we {location}  minuty
-jaki będzie godzina we {location}  minuty od teraz
-jaki będzie godzina we {location}  sekund
-jaki będzie godzina we {location}  sekund od teraz
-jaki będzie godzina we {location}  sekundy
-jaki będzie godzina we {location}  sekundy od teraz
-jaki będzie godzina we {location}  {offset} godzin
-jaki będzie godzina we {location}  {offset} godzin od teraz
-jaki będzie godzina we {location}  {offset} godziny
-jaki będzie godzina we {location}  {offset} godziny od teraz
-jaki będzie godzina we {location}  {offset} minut
-jaki będzie godzina we {location}  {offset} minut od teraz
-jaki będzie godzina we {location}  {offset} minuty
-jaki będzie godzina we {location}  {offset} minuty od teraz
-jaki będzie godzina we {location}  {offset} sekund
-jaki będzie godzina we {location}  {offset} sekund od teraz
-jaki będzie godzina we {location}  {offset} sekundy
-jaki będzie godzina we {location}  {offset} sekundy od teraz
+jaki będzie godzina w {location} za {offset} godzin
+jaki będzie godzina w {location} za {offset} godzin od teraz
+jaki będzie godzina w {location} za {offset} godziny
+jaki będzie godzina w {location} za {offset} godziny od teraz
+jaki będzie godzina w {location} za {offset} minut
+jaki będzie godzina w {location} za {offset} minut od teraz
+jaki będzie godzina w {location} za {offset} minuty
+jaki będzie godzina w {location} za {offset} minuty od teraz
+jaki będzie godzina w {location} za {offset} sekund
+jaki będzie godzina w {location} za {offset} sekund od teraz
+jaki będzie godzina w {location} za {offset} sekundy
+jaki będzie godzina w {location} za {offset} sekundy od teraz
+jaki będzie godzina we {location} za {offset} godzin
+jaki będzie godzina we {location} za {offset} godzin od teraz
+jaki będzie godzina we {location} za {offset} godziny
+jaki będzie godzina we {location} za {offset} godziny od teraz
+jaki będzie godzina we {location} za {offset} minut
+jaki będzie godzina we {location} za {offset} minut od teraz
+jaki będzie godzina we {location} za {offset} minuty
+jaki będzie godzina we {location} za {offset} minuty od teraz
+jaki będzie godzina we {location} za {offset} sekund
+jaki będzie godzina we {location} za {offset} sekund od teraz
+jaki będzie godzina we {location} za {offset} sekundy
+jaki będzie godzina we {location} za {offset} sekundy od teraz
 jaki będzie godzina we {location} za {offset} godzin
 jaki będzie godzina we {location} za {offset} godzin od teraz
 jaki będzie godzina we {location} za {offset} godziny
@@ -1294,42 +1150,6 @@ jaki będzie godzina za {offset} sekundy od teraz w {location}
 jaki będzie godzina za {offset} sekundy od teraz we {location}
 jaki będzie godzina za {offset} sekundy w {location}
 jaki będzie godzina za {offset} sekundy we {location}
-jaki czas będzie  godzin
-jaki czas będzie  godzin od teraz
-jaki czas będzie  godzin od teraz w {location}
-jaki czas będzie  godzin od teraz we {location}
-jaki czas będzie  godzin w {location}
-jaki czas będzie  godzin we {location}
-jaki czas będzie  godziny
-jaki czas będzie  godziny od teraz
-jaki czas będzie  godziny od teraz w {location}
-jaki czas będzie  godziny od teraz we {location}
-jaki czas będzie  godziny w {location}
-jaki czas będzie  godziny we {location}
-jaki czas będzie  minut
-jaki czas będzie  minut od teraz
-jaki czas będzie  minut od teraz w {location}
-jaki czas będzie  minut od teraz we {location}
-jaki czas będzie  minut w {location}
-jaki czas będzie  minut we {location}
-jaki czas będzie  minuty
-jaki czas będzie  minuty od teraz
-jaki czas będzie  minuty od teraz w {location}
-jaki czas będzie  minuty od teraz we {location}
-jaki czas będzie  minuty w {location}
-jaki czas będzie  minuty we {location}
-jaki czas będzie  sekund
-jaki czas będzie  sekund od teraz
-jaki czas będzie  sekund od teraz w {location}
-jaki czas będzie  sekund od teraz we {location}
-jaki czas będzie  sekund w {location}
-jaki czas będzie  sekund we {location}
-jaki czas będzie  sekundy
-jaki czas będzie  sekundy od teraz
-jaki czas będzie  sekundy od teraz w {location}
-jaki czas będzie  sekundy od teraz we {location}
-jaki czas będzie  sekundy w {location}
-jaki czas będzie  sekundy we {location}
 jaki czas będzie za {offset} godzin
 jaki czas będzie za {offset} godzin od teraz
 jaki czas będzie za {offset} godzin od teraz w {location}
@@ -1366,42 +1186,42 @@ jaki czas będzie za {offset} sekundy od teraz w {location}
 jaki czas będzie za {offset} sekundy od teraz we {location}
 jaki czas będzie za {offset} sekundy w {location}
 jaki czas będzie za {offset} sekundy we {location}
-jaki czas jest  godzin
-jaki czas jest  godzin od teraz
-jaki czas jest  godzin od teraz w {location}
-jaki czas jest  godzin od teraz we {location}
-jaki czas jest  godzin w {location}
-jaki czas jest  godzin we {location}
-jaki czas jest  godziny
-jaki czas jest  godziny od teraz
-jaki czas jest  godziny od teraz w {location}
-jaki czas jest  godziny od teraz we {location}
-jaki czas jest  godziny w {location}
-jaki czas jest  godziny we {location}
-jaki czas jest  minut
-jaki czas jest  minut od teraz
-jaki czas jest  minut od teraz w {location}
-jaki czas jest  minut od teraz we {location}
-jaki czas jest  minut w {location}
-jaki czas jest  minut we {location}
-jaki czas jest  minuty
-jaki czas jest  minuty od teraz
-jaki czas jest  minuty od teraz w {location}
-jaki czas jest  minuty od teraz we {location}
-jaki czas jest  minuty w {location}
-jaki czas jest  minuty we {location}
-jaki czas jest  sekund
-jaki czas jest  sekund od teraz
-jaki czas jest  sekund od teraz w {location}
-jaki czas jest  sekund od teraz we {location}
-jaki czas jest  sekund w {location}
-jaki czas jest  sekund we {location}
-jaki czas jest  sekundy
-jaki czas jest  sekundy od teraz
-jaki czas jest  sekundy od teraz w {location}
-jaki czas jest  sekundy od teraz we {location}
-jaki czas jest  sekundy w {location}
-jaki czas jest  sekundy we {location}
+jaki czas będzie za {offset} godzin
+jaki czas będzie za {offset} godzin od teraz
+jaki czas będzie za {offset} godzin od teraz w {location}
+jaki czas będzie za {offset} godzin od teraz we {location}
+jaki czas będzie za {offset} godzin w {location}
+jaki czas będzie za {offset} godzin we {location}
+jaki czas będzie za {offset} godziny
+jaki czas będzie za {offset} godziny od teraz
+jaki czas będzie za {offset} godziny od teraz w {location}
+jaki czas będzie za {offset} godziny od teraz we {location}
+jaki czas będzie za {offset} godziny w {location}
+jaki czas będzie za {offset} godziny we {location}
+jaki czas będzie za {offset} minut
+jaki czas będzie za {offset} minut od teraz
+jaki czas będzie za {offset} minut od teraz w {location}
+jaki czas będzie za {offset} minut od teraz we {location}
+jaki czas będzie za {offset} minut w {location}
+jaki czas będzie za {offset} minut we {location}
+jaki czas będzie za {offset} minuty
+jaki czas będzie za {offset} minuty od teraz
+jaki czas będzie za {offset} minuty od teraz w {location}
+jaki czas będzie za {offset} minuty od teraz we {location}
+jaki czas będzie za {offset} minuty w {location}
+jaki czas będzie za {offset} minuty we {location}
+jaki czas będzie za {offset} sekund
+jaki czas będzie za {offset} sekund od teraz
+jaki czas będzie za {offset} sekund od teraz w {location}
+jaki czas będzie za {offset} sekund od teraz we {location}
+jaki czas będzie za {offset} sekund w {location}
+jaki czas będzie za {offset} sekund we {location}
+jaki czas będzie za {offset} sekundy
+jaki czas będzie za {offset} sekundy od teraz
+jaki czas będzie za {offset} sekundy od teraz w {location}
+jaki czas będzie za {offset} sekundy od teraz we {location}
+jaki czas będzie za {offset} sekundy w {location}
+jaki czas będzie za {offset} sekundy we {location}
 jaki czas jest za {offset} godzin
 jaki czas jest za {offset} godzin od teraz
 jaki czas jest za {offset} godzin od teraz w {location}
@@ -1438,42 +1258,42 @@ jaki czas jest za {offset} sekundy od teraz w {location}
 jaki czas jest za {offset} sekundy od teraz we {location}
 jaki czas jest za {offset} sekundy w {location}
 jaki czas jest za {offset} sekundy we {location}
-jaki godzina będzie  godzin
-jaki godzina będzie  godzin od teraz
-jaki godzina będzie  godzin od teraz w {location}
-jaki godzina będzie  godzin od teraz we {location}
-jaki godzina będzie  godzin w {location}
-jaki godzina będzie  godzin we {location}
-jaki godzina będzie  godziny
-jaki godzina będzie  godziny od teraz
-jaki godzina będzie  godziny od teraz w {location}
-jaki godzina będzie  godziny od teraz we {location}
-jaki godzina będzie  godziny w {location}
-jaki godzina będzie  godziny we {location}
-jaki godzina będzie  minut
-jaki godzina będzie  minut od teraz
-jaki godzina będzie  minut od teraz w {location}
-jaki godzina będzie  minut od teraz we {location}
-jaki godzina będzie  minut w {location}
-jaki godzina będzie  minut we {location}
-jaki godzina będzie  minuty
-jaki godzina będzie  minuty od teraz
-jaki godzina będzie  minuty od teraz w {location}
-jaki godzina będzie  minuty od teraz we {location}
-jaki godzina będzie  minuty w {location}
-jaki godzina będzie  minuty we {location}
-jaki godzina będzie  sekund
-jaki godzina będzie  sekund od teraz
-jaki godzina będzie  sekund od teraz w {location}
-jaki godzina będzie  sekund od teraz we {location}
-jaki godzina będzie  sekund w {location}
-jaki godzina będzie  sekund we {location}
-jaki godzina będzie  sekundy
-jaki godzina będzie  sekundy od teraz
-jaki godzina będzie  sekundy od teraz w {location}
-jaki godzina będzie  sekundy od teraz we {location}
-jaki godzina będzie  sekundy w {location}
-jaki godzina będzie  sekundy we {location}
+jaki czas jest za {offset} godzin
+jaki czas jest za {offset} godzin od teraz
+jaki czas jest za {offset} godzin od teraz w {location}
+jaki czas jest za {offset} godzin od teraz we {location}
+jaki czas jest za {offset} godzin w {location}
+jaki czas jest za {offset} godzin we {location}
+jaki czas jest za {offset} godziny
+jaki czas jest za {offset} godziny od teraz
+jaki czas jest za {offset} godziny od teraz w {location}
+jaki czas jest za {offset} godziny od teraz we {location}
+jaki czas jest za {offset} godziny w {location}
+jaki czas jest za {offset} godziny we {location}
+jaki czas jest za {offset} minut
+jaki czas jest za {offset} minut od teraz
+jaki czas jest za {offset} minut od teraz w {location}
+jaki czas jest za {offset} minut od teraz we {location}
+jaki czas jest za {offset} minut w {location}
+jaki czas jest za {offset} minut we {location}
+jaki czas jest za {offset} minuty
+jaki czas jest za {offset} minuty od teraz
+jaki czas jest za {offset} minuty od teraz w {location}
+jaki czas jest za {offset} minuty od teraz we {location}
+jaki czas jest za {offset} minuty w {location}
+jaki czas jest za {offset} minuty we {location}
+jaki czas jest za {offset} sekund
+jaki czas jest za {offset} sekund od teraz
+jaki czas jest za {offset} sekund od teraz w {location}
+jaki czas jest za {offset} sekund od teraz we {location}
+jaki czas jest za {offset} sekund w {location}
+jaki czas jest za {offset} sekund we {location}
+jaki czas jest za {offset} sekundy
+jaki czas jest za {offset} sekundy od teraz
+jaki czas jest za {offset} sekundy od teraz w {location}
+jaki czas jest za {offset} sekundy od teraz we {location}
+jaki czas jest za {offset} sekundy w {location}
+jaki czas jest za {offset} sekundy we {location}
 jaki godzina będzie za {offset} godzin
 jaki godzina będzie za {offset} godzin od teraz
 jaki godzina będzie za {offset} godzin od teraz w {location}
@@ -1510,42 +1330,42 @@ jaki godzina będzie za {offset} sekundy od teraz w {location}
 jaki godzina będzie za {offset} sekundy od teraz we {location}
 jaki godzina będzie za {offset} sekundy w {location}
 jaki godzina będzie za {offset} sekundy we {location}
-jaki godzina jest  godzin
-jaki godzina jest  godzin od teraz
-jaki godzina jest  godzin od teraz w {location}
-jaki godzina jest  godzin od teraz we {location}
-jaki godzina jest  godzin w {location}
-jaki godzina jest  godzin we {location}
-jaki godzina jest  godziny
-jaki godzina jest  godziny od teraz
-jaki godzina jest  godziny od teraz w {location}
-jaki godzina jest  godziny od teraz we {location}
-jaki godzina jest  godziny w {location}
-jaki godzina jest  godziny we {location}
-jaki godzina jest  minut
-jaki godzina jest  minut od teraz
-jaki godzina jest  minut od teraz w {location}
-jaki godzina jest  minut od teraz we {location}
-jaki godzina jest  minut w {location}
-jaki godzina jest  minut we {location}
-jaki godzina jest  minuty
-jaki godzina jest  minuty od teraz
-jaki godzina jest  minuty od teraz w {location}
-jaki godzina jest  minuty od teraz we {location}
-jaki godzina jest  minuty w {location}
-jaki godzina jest  minuty we {location}
-jaki godzina jest  sekund
-jaki godzina jest  sekund od teraz
-jaki godzina jest  sekund od teraz w {location}
-jaki godzina jest  sekund od teraz we {location}
-jaki godzina jest  sekund w {location}
-jaki godzina jest  sekund we {location}
-jaki godzina jest  sekundy
-jaki godzina jest  sekundy od teraz
-jaki godzina jest  sekundy od teraz w {location}
-jaki godzina jest  sekundy od teraz we {location}
-jaki godzina jest  sekundy w {location}
-jaki godzina jest  sekundy we {location}
+jaki godzina będzie za {offset} godzin
+jaki godzina będzie za {offset} godzin od teraz
+jaki godzina będzie za {offset} godzin od teraz w {location}
+jaki godzina będzie za {offset} godzin od teraz we {location}
+jaki godzina będzie za {offset} godzin w {location}
+jaki godzina będzie za {offset} godzin we {location}
+jaki godzina będzie za {offset} godziny
+jaki godzina będzie za {offset} godziny od teraz
+jaki godzina będzie za {offset} godziny od teraz w {location}
+jaki godzina będzie za {offset} godziny od teraz we {location}
+jaki godzina będzie za {offset} godziny w {location}
+jaki godzina będzie za {offset} godziny we {location}
+jaki godzina będzie za {offset} minut
+jaki godzina będzie za {offset} minut od teraz
+jaki godzina będzie za {offset} minut od teraz w {location}
+jaki godzina będzie za {offset} minut od teraz we {location}
+jaki godzina będzie za {offset} minut w {location}
+jaki godzina będzie za {offset} minut we {location}
+jaki godzina będzie za {offset} minuty
+jaki godzina będzie za {offset} minuty od teraz
+jaki godzina będzie za {offset} minuty od teraz w {location}
+jaki godzina będzie za {offset} minuty od teraz we {location}
+jaki godzina będzie za {offset} minuty w {location}
+jaki godzina będzie za {offset} minuty we {location}
+jaki godzina będzie za {offset} sekund
+jaki godzina będzie za {offset} sekund od teraz
+jaki godzina będzie za {offset} sekund od teraz w {location}
+jaki godzina będzie za {offset} sekund od teraz we {location}
+jaki godzina będzie za {offset} sekund w {location}
+jaki godzina będzie za {offset} sekund we {location}
+jaki godzina będzie za {offset} sekundy
+jaki godzina będzie za {offset} sekundy od teraz
+jaki godzina będzie za {offset} sekundy od teraz w {location}
+jaki godzina będzie za {offset} sekundy od teraz we {location}
+jaki godzina będzie za {offset} sekundy w {location}
+jaki godzina będzie za {offset} sekundy we {location}
 jaki godzina jest za {offset} godzin
 jaki godzina jest za {offset} godzin od teraz
 jaki godzina jest za {offset} godzin od teraz w {location}
@@ -1582,66 +1402,78 @@ jaki godzina jest za {offset} sekundy od teraz w {location}
 jaki godzina jest za {offset} sekundy od teraz we {location}
 jaki godzina jest za {offset} sekundy w {location}
 jaki godzina jest za {offset} sekundy we {location}
-jaki jest czas  godzin
-jaki jest czas  godzin od teraz
-jaki jest czas  godzin od teraz w {location}
-jaki jest czas  godzin od teraz we {location}
-jaki jest czas  godzin w {location}
-jaki jest czas  godzin we {location}
-jaki jest czas  godziny
-jaki jest czas  godziny od teraz
-jaki jest czas  godziny od teraz w {location}
-jaki jest czas  godziny od teraz we {location}
-jaki jest czas  godziny w {location}
-jaki jest czas  godziny we {location}
-jaki jest czas  minut
-jaki jest czas  minut od teraz
-jaki jest czas  minut od teraz w {location}
-jaki jest czas  minut od teraz we {location}
-jaki jest czas  minut w {location}
-jaki jest czas  minut we {location}
-jaki jest czas  minuty
-jaki jest czas  minuty od teraz
-jaki jest czas  minuty od teraz w {location}
-jaki jest czas  minuty od teraz we {location}
-jaki jest czas  minuty w {location}
-jaki jest czas  minuty we {location}
-jaki jest czas  sekund
-jaki jest czas  sekund od teraz
-jaki jest czas  sekund od teraz w {location}
-jaki jest czas  sekund od teraz we {location}
-jaki jest czas  sekund w {location}
-jaki jest czas  sekund we {location}
-jaki jest czas  sekundy
-jaki jest czas  sekundy od teraz
-jaki jest czas  sekundy od teraz w {location}
-jaki jest czas  sekundy od teraz we {location}
-jaki jest czas  sekundy w {location}
-jaki jest czas  sekundy we {location}
-jaki jest czas w {location}  godzin
-jaki jest czas w {location}  godzin od teraz
-jaki jest czas w {location}  godziny
-jaki jest czas w {location}  godziny od teraz
-jaki jest czas w {location}  minut
-jaki jest czas w {location}  minut od teraz
-jaki jest czas w {location}  minuty
-jaki jest czas w {location}  minuty od teraz
-jaki jest czas w {location}  sekund
-jaki jest czas w {location}  sekund od teraz
-jaki jest czas w {location}  sekundy
-jaki jest czas w {location}  sekundy od teraz
-jaki jest czas w {location}  {offset} godzin
-jaki jest czas w {location}  {offset} godzin od teraz
-jaki jest czas w {location}  {offset} godziny
-jaki jest czas w {location}  {offset} godziny od teraz
-jaki jest czas w {location}  {offset} minut
-jaki jest czas w {location}  {offset} minut od teraz
-jaki jest czas w {location}  {offset} minuty
-jaki jest czas w {location}  {offset} minuty od teraz
-jaki jest czas w {location}  {offset} sekund
-jaki jest czas w {location}  {offset} sekund od teraz
-jaki jest czas w {location}  {offset} sekundy
-jaki jest czas w {location}  {offset} sekundy od teraz
+jaki godzina jest za {offset} godzin
+jaki godzina jest za {offset} godzin od teraz
+jaki godzina jest za {offset} godzin od teraz w {location}
+jaki godzina jest za {offset} godzin od teraz we {location}
+jaki godzina jest za {offset} godzin w {location}
+jaki godzina jest za {offset} godzin we {location}
+jaki godzina jest za {offset} godziny
+jaki godzina jest za {offset} godziny od teraz
+jaki godzina jest za {offset} godziny od teraz w {location}
+jaki godzina jest za {offset} godziny od teraz we {location}
+jaki godzina jest za {offset} godziny w {location}
+jaki godzina jest za {offset} godziny we {location}
+jaki godzina jest za {offset} minut
+jaki godzina jest za {offset} minut od teraz
+jaki godzina jest za {offset} minut od teraz w {location}
+jaki godzina jest za {offset} minut od teraz we {location}
+jaki godzina jest za {offset} minut w {location}
+jaki godzina jest za {offset} minut we {location}
+jaki godzina jest za {offset} minuty
+jaki godzina jest za {offset} minuty od teraz
+jaki godzina jest za {offset} minuty od teraz w {location}
+jaki godzina jest za {offset} minuty od teraz we {location}
+jaki godzina jest za {offset} minuty w {location}
+jaki godzina jest za {offset} minuty we {location}
+jaki godzina jest za {offset} sekund
+jaki godzina jest za {offset} sekund od teraz
+jaki godzina jest za {offset} sekund od teraz w {location}
+jaki godzina jest za {offset} sekund od teraz we {location}
+jaki godzina jest za {offset} sekund w {location}
+jaki godzina jest za {offset} sekund we {location}
+jaki godzina jest za {offset} sekundy
+jaki godzina jest za {offset} sekundy od teraz
+jaki godzina jest za {offset} sekundy od teraz w {location}
+jaki godzina jest za {offset} sekundy od teraz we {location}
+jaki godzina jest za {offset} sekundy w {location}
+jaki godzina jest za {offset} sekundy we {location}
+jaki jest czas za {offset} godzin
+jaki jest czas za {offset} godzin od teraz
+jaki jest czas za {offset} godzin od teraz w {location}
+jaki jest czas za {offset} godzin od teraz we {location}
+jaki jest czas za {offset} godzin w {location}
+jaki jest czas za {offset} godzin we {location}
+jaki jest czas za {offset} godziny
+jaki jest czas za {offset} godziny od teraz
+jaki jest czas za {offset} godziny od teraz w {location}
+jaki jest czas za {offset} godziny od teraz we {location}
+jaki jest czas za {offset} godziny w {location}
+jaki jest czas za {offset} godziny we {location}
+jaki jest czas za {offset} minut
+jaki jest czas za {offset} minut od teraz
+jaki jest czas za {offset} minut od teraz w {location}
+jaki jest czas za {offset} minut od teraz we {location}
+jaki jest czas za {offset} minut w {location}
+jaki jest czas za {offset} minut we {location}
+jaki jest czas za {offset} minuty
+jaki jest czas za {offset} minuty od teraz
+jaki jest czas za {offset} minuty od teraz w {location}
+jaki jest czas za {offset} minuty od teraz we {location}
+jaki jest czas za {offset} minuty w {location}
+jaki jest czas za {offset} minuty we {location}
+jaki jest czas za {offset} sekund
+jaki jest czas za {offset} sekund od teraz
+jaki jest czas za {offset} sekund od teraz w {location}
+jaki jest czas za {offset} sekund od teraz we {location}
+jaki jest czas za {offset} sekund w {location}
+jaki jest czas za {offset} sekund we {location}
+jaki jest czas za {offset} sekundy
+jaki jest czas za {offset} sekundy od teraz
+jaki jest czas za {offset} sekundy od teraz w {location}
+jaki jest czas za {offset} sekundy od teraz we {location}
+jaki jest czas za {offset} sekundy w {location}
+jaki jest czas za {offset} sekundy we {location}
 jaki jest czas w {location} za {offset} godzin
 jaki jest czas w {location} za {offset} godzin od teraz
 jaki jest czas w {location} za {offset} godziny
@@ -1654,30 +1486,30 @@ jaki jest czas w {location} za {offset} sekund
 jaki jest czas w {location} za {offset} sekund od teraz
 jaki jest czas w {location} za {offset} sekundy
 jaki jest czas w {location} za {offset} sekundy od teraz
-jaki jest czas we {location}  godzin
-jaki jest czas we {location}  godzin od teraz
-jaki jest czas we {location}  godziny
-jaki jest czas we {location}  godziny od teraz
-jaki jest czas we {location}  minut
-jaki jest czas we {location}  minut od teraz
-jaki jest czas we {location}  minuty
-jaki jest czas we {location}  minuty od teraz
-jaki jest czas we {location}  sekund
-jaki jest czas we {location}  sekund od teraz
-jaki jest czas we {location}  sekundy
-jaki jest czas we {location}  sekundy od teraz
-jaki jest czas we {location}  {offset} godzin
-jaki jest czas we {location}  {offset} godzin od teraz
-jaki jest czas we {location}  {offset} godziny
-jaki jest czas we {location}  {offset} godziny od teraz
-jaki jest czas we {location}  {offset} minut
-jaki jest czas we {location}  {offset} minut od teraz
-jaki jest czas we {location}  {offset} minuty
-jaki jest czas we {location}  {offset} minuty od teraz
-jaki jest czas we {location}  {offset} sekund
-jaki jest czas we {location}  {offset} sekund od teraz
-jaki jest czas we {location}  {offset} sekundy
-jaki jest czas we {location}  {offset} sekundy od teraz
+jaki jest czas w {location} za {offset} godzin
+jaki jest czas w {location} za {offset} godzin od teraz
+jaki jest czas w {location} za {offset} godziny
+jaki jest czas w {location} za {offset} godziny od teraz
+jaki jest czas w {location} za {offset} minut
+jaki jest czas w {location} za {offset} minut od teraz
+jaki jest czas w {location} za {offset} minuty
+jaki jest czas w {location} za {offset} minuty od teraz
+jaki jest czas w {location} za {offset} sekund
+jaki jest czas w {location} za {offset} sekund od teraz
+jaki jest czas w {location} za {offset} sekundy
+jaki jest czas w {location} za {offset} sekundy od teraz
+jaki jest czas we {location} za {offset} godzin
+jaki jest czas we {location} za {offset} godzin od teraz
+jaki jest czas we {location} za {offset} godziny
+jaki jest czas we {location} za {offset} godziny od teraz
+jaki jest czas we {location} za {offset} minut
+jaki jest czas we {location} za {offset} minut od teraz
+jaki jest czas we {location} za {offset} minuty
+jaki jest czas we {location} za {offset} minuty od teraz
+jaki jest czas we {location} za {offset} sekund
+jaki jest czas we {location} za {offset} sekund od teraz
+jaki jest czas we {location} za {offset} sekundy
+jaki jest czas we {location} za {offset} sekundy od teraz
 jaki jest czas we {location} za {offset} godzin
 jaki jest czas we {location} za {offset} godzin od teraz
 jaki jest czas we {location} za {offset} godziny
@@ -1726,66 +1558,42 @@ jaki jest czas za {offset} sekundy od teraz w {location}
 jaki jest czas za {offset} sekundy od teraz we {location}
 jaki jest czas za {offset} sekundy w {location}
 jaki jest czas za {offset} sekundy we {location}
-jaki jest godzina  godzin
-jaki jest godzina  godzin od teraz
-jaki jest godzina  godzin od teraz w {location}
-jaki jest godzina  godzin od teraz we {location}
-jaki jest godzina  godzin w {location}
-jaki jest godzina  godzin we {location}
-jaki jest godzina  godziny
-jaki jest godzina  godziny od teraz
-jaki jest godzina  godziny od teraz w {location}
-jaki jest godzina  godziny od teraz we {location}
-jaki jest godzina  godziny w {location}
-jaki jest godzina  godziny we {location}
-jaki jest godzina  minut
-jaki jest godzina  minut od teraz
-jaki jest godzina  minut od teraz w {location}
-jaki jest godzina  minut od teraz we {location}
-jaki jest godzina  minut w {location}
-jaki jest godzina  minut we {location}
-jaki jest godzina  minuty
-jaki jest godzina  minuty od teraz
-jaki jest godzina  minuty od teraz w {location}
-jaki jest godzina  minuty od teraz we {location}
-jaki jest godzina  minuty w {location}
-jaki jest godzina  minuty we {location}
-jaki jest godzina  sekund
-jaki jest godzina  sekund od teraz
-jaki jest godzina  sekund od teraz w {location}
-jaki jest godzina  sekund od teraz we {location}
-jaki jest godzina  sekund w {location}
-jaki jest godzina  sekund we {location}
-jaki jest godzina  sekundy
-jaki jest godzina  sekundy od teraz
-jaki jest godzina  sekundy od teraz w {location}
-jaki jest godzina  sekundy od teraz we {location}
-jaki jest godzina  sekundy w {location}
-jaki jest godzina  sekundy we {location}
-jaki jest godzina w {location}  godzin
-jaki jest godzina w {location}  godzin od teraz
-jaki jest godzina w {location}  godziny
-jaki jest godzina w {location}  godziny od teraz
-jaki jest godzina w {location}  minut
-jaki jest godzina w {location}  minut od teraz
-jaki jest godzina w {location}  minuty
-jaki jest godzina w {location}  minuty od teraz
-jaki jest godzina w {location}  sekund
-jaki jest godzina w {location}  sekund od teraz
-jaki jest godzina w {location}  sekundy
-jaki jest godzina w {location}  sekundy od teraz
-jaki jest godzina w {location}  {offset} godzin
-jaki jest godzina w {location}  {offset} godzin od teraz
-jaki jest godzina w {location}  {offset} godziny
-jaki jest godzina w {location}  {offset} godziny od teraz
-jaki jest godzina w {location}  {offset} minut
-jaki jest godzina w {location}  {offset} minut od teraz
-jaki jest godzina w {location}  {offset} minuty
-jaki jest godzina w {location}  {offset} minuty od teraz
-jaki jest godzina w {location}  {offset} sekund
-jaki jest godzina w {location}  {offset} sekund od teraz
-jaki jest godzina w {location}  {offset} sekundy
-jaki jest godzina w {location}  {offset} sekundy od teraz
+jaki jest godzina za {offset} godzin
+jaki jest godzina za {offset} godzin od teraz
+jaki jest godzina za {offset} godzin od teraz w {location}
+jaki jest godzina za {offset} godzin od teraz we {location}
+jaki jest godzina za {offset} godzin w {location}
+jaki jest godzina za {offset} godzin we {location}
+jaki jest godzina za {offset} godziny
+jaki jest godzina za {offset} godziny od teraz
+jaki jest godzina za {offset} godziny od teraz w {location}
+jaki jest godzina za {offset} godziny od teraz we {location}
+jaki jest godzina za {offset} godziny w {location}
+jaki jest godzina za {offset} godziny we {location}
+jaki jest godzina za {offset} minut
+jaki jest godzina za {offset} minut od teraz
+jaki jest godzina za {offset} minut od teraz w {location}
+jaki jest godzina za {offset} minut od teraz we {location}
+jaki jest godzina za {offset} minut w {location}
+jaki jest godzina za {offset} minut we {location}
+jaki jest godzina za {offset} minuty
+jaki jest godzina za {offset} minuty od teraz
+jaki jest godzina za {offset} minuty od teraz w {location}
+jaki jest godzina za {offset} minuty od teraz we {location}
+jaki jest godzina za {offset} minuty w {location}
+jaki jest godzina za {offset} minuty we {location}
+jaki jest godzina za {offset} sekund
+jaki jest godzina za {offset} sekund od teraz
+jaki jest godzina za {offset} sekund od teraz w {location}
+jaki jest godzina za {offset} sekund od teraz we {location}
+jaki jest godzina za {offset} sekund w {location}
+jaki jest godzina za {offset} sekund we {location}
+jaki jest godzina za {offset} sekundy
+jaki jest godzina za {offset} sekundy od teraz
+jaki jest godzina za {offset} sekundy od teraz w {location}
+jaki jest godzina za {offset} sekundy od teraz we {location}
+jaki jest godzina za {offset} sekundy w {location}
+jaki jest godzina za {offset} sekundy we {location}
 jaki jest godzina w {location} za {offset} godzin
 jaki jest godzina w {location} za {offset} godzin od teraz
 jaki jest godzina w {location} za {offset} godziny
@@ -1798,30 +1606,30 @@ jaki jest godzina w {location} za {offset} sekund
 jaki jest godzina w {location} za {offset} sekund od teraz
 jaki jest godzina w {location} za {offset} sekundy
 jaki jest godzina w {location} za {offset} sekundy od teraz
-jaki jest godzina we {location}  godzin
-jaki jest godzina we {location}  godzin od teraz
-jaki jest godzina we {location}  godziny
-jaki jest godzina we {location}  godziny od teraz
-jaki jest godzina we {location}  minut
-jaki jest godzina we {location}  minut od teraz
-jaki jest godzina we {location}  minuty
-jaki jest godzina we {location}  minuty od teraz
-jaki jest godzina we {location}  sekund
-jaki jest godzina we {location}  sekund od teraz
-jaki jest godzina we {location}  sekundy
-jaki jest godzina we {location}  sekundy od teraz
-jaki jest godzina we {location}  {offset} godzin
-jaki jest godzina we {location}  {offset} godzin od teraz
-jaki jest godzina we {location}  {offset} godziny
-jaki jest godzina we {location}  {offset} godziny od teraz
-jaki jest godzina we {location}  {offset} minut
-jaki jest godzina we {location}  {offset} minut od teraz
-jaki jest godzina we {location}  {offset} minuty
-jaki jest godzina we {location}  {offset} minuty od teraz
-jaki jest godzina we {location}  {offset} sekund
-jaki jest godzina we {location}  {offset} sekund od teraz
-jaki jest godzina we {location}  {offset} sekundy
-jaki jest godzina we {location}  {offset} sekundy od teraz
+jaki jest godzina w {location} za {offset} godzin
+jaki jest godzina w {location} za {offset} godzin od teraz
+jaki jest godzina w {location} za {offset} godziny
+jaki jest godzina w {location} za {offset} godziny od teraz
+jaki jest godzina w {location} za {offset} minut
+jaki jest godzina w {location} za {offset} minut od teraz
+jaki jest godzina w {location} za {offset} minuty
+jaki jest godzina w {location} za {offset} minuty od teraz
+jaki jest godzina w {location} za {offset} sekund
+jaki jest godzina w {location} za {offset} sekund od teraz
+jaki jest godzina w {location} za {offset} sekundy
+jaki jest godzina w {location} za {offset} sekundy od teraz
+jaki jest godzina we {location} za {offset} godzin
+jaki jest godzina we {location} za {offset} godzin od teraz
+jaki jest godzina we {location} za {offset} godziny
+jaki jest godzina we {location} za {offset} godziny od teraz
+jaki jest godzina we {location} za {offset} minut
+jaki jest godzina we {location} za {offset} minut od teraz
+jaki jest godzina we {location} za {offset} minuty
+jaki jest godzina we {location} za {offset} minuty od teraz
+jaki jest godzina we {location} za {offset} sekund
+jaki jest godzina we {location} za {offset} sekund od teraz
+jaki jest godzina we {location} za {offset} sekundy
+jaki jest godzina we {location} za {offset} sekundy od teraz
 jaki jest godzina we {location} za {offset} godzin
 jaki jest godzina we {location} za {offset} godzin od teraz
 jaki jest godzina we {location} za {offset} godziny
@@ -1942,66 +1750,42 @@ kiedy miną {offset} sekundy od teraz w {location}
 kiedy miną {offset} sekundy od teraz we {location}
 kiedy miną {offset} sekundy w {location}
 kiedy miną {offset} sekundy we {location}
-która będzie czas  godzin
-która będzie czas  godzin od teraz
-która będzie czas  godzin od teraz w {location}
-która będzie czas  godzin od teraz we {location}
-która będzie czas  godzin w {location}
-która będzie czas  godzin we {location}
-która będzie czas  godziny
-która będzie czas  godziny od teraz
-która będzie czas  godziny od teraz w {location}
-która będzie czas  godziny od teraz we {location}
-która będzie czas  godziny w {location}
-która będzie czas  godziny we {location}
-która będzie czas  minut
-która będzie czas  minut od teraz
-która będzie czas  minut od teraz w {location}
-która będzie czas  minut od teraz we {location}
-która będzie czas  minut w {location}
-która będzie czas  minut we {location}
-która będzie czas  minuty
-która będzie czas  minuty od teraz
-która będzie czas  minuty od teraz w {location}
-która będzie czas  minuty od teraz we {location}
-która będzie czas  minuty w {location}
-która będzie czas  minuty we {location}
-która będzie czas  sekund
-która będzie czas  sekund od teraz
-która będzie czas  sekund od teraz w {location}
-która będzie czas  sekund od teraz we {location}
-która będzie czas  sekund w {location}
-która będzie czas  sekund we {location}
-która będzie czas  sekundy
-która będzie czas  sekundy od teraz
-która będzie czas  sekundy od teraz w {location}
-która będzie czas  sekundy od teraz we {location}
-która będzie czas  sekundy w {location}
-która będzie czas  sekundy we {location}
-która będzie czas w {location}  godzin
-która będzie czas w {location}  godzin od teraz
-która będzie czas w {location}  godziny
-która będzie czas w {location}  godziny od teraz
-która będzie czas w {location}  minut
-która będzie czas w {location}  minut od teraz
-która będzie czas w {location}  minuty
-która będzie czas w {location}  minuty od teraz
-która będzie czas w {location}  sekund
-która będzie czas w {location}  sekund od teraz
-która będzie czas w {location}  sekundy
-która będzie czas w {location}  sekundy od teraz
-która będzie czas w {location}  {offset} godzin
-która będzie czas w {location}  {offset} godzin od teraz
-która będzie czas w {location}  {offset} godziny
-która będzie czas w {location}  {offset} godziny od teraz
-która będzie czas w {location}  {offset} minut
-która będzie czas w {location}  {offset} minut od teraz
-która będzie czas w {location}  {offset} minuty
-która będzie czas w {location}  {offset} minuty od teraz
-która będzie czas w {location}  {offset} sekund
-która będzie czas w {location}  {offset} sekund od teraz
-która będzie czas w {location}  {offset} sekundy
-która będzie czas w {location}  {offset} sekundy od teraz
+która będzie czas za {offset} godzin
+która będzie czas za {offset} godzin od teraz
+która będzie czas za {offset} godzin od teraz w {location}
+która będzie czas za {offset} godzin od teraz we {location}
+która będzie czas za {offset} godzin w {location}
+która będzie czas za {offset} godzin we {location}
+która będzie czas za {offset} godziny
+która będzie czas za {offset} godziny od teraz
+która będzie czas za {offset} godziny od teraz w {location}
+która będzie czas za {offset} godziny od teraz we {location}
+która będzie czas za {offset} godziny w {location}
+która będzie czas za {offset} godziny we {location}
+która będzie czas za {offset} minut
+która będzie czas za {offset} minut od teraz
+która będzie czas za {offset} minut od teraz w {location}
+która będzie czas za {offset} minut od teraz we {location}
+która będzie czas za {offset} minut w {location}
+która będzie czas za {offset} minut we {location}
+która będzie czas za {offset} minuty
+która będzie czas za {offset} minuty od teraz
+która będzie czas za {offset} minuty od teraz w {location}
+która będzie czas za {offset} minuty od teraz we {location}
+która będzie czas za {offset} minuty w {location}
+która będzie czas za {offset} minuty we {location}
+która będzie czas za {offset} sekund
+która będzie czas za {offset} sekund od teraz
+która będzie czas za {offset} sekund od teraz w {location}
+która będzie czas za {offset} sekund od teraz we {location}
+która będzie czas za {offset} sekund w {location}
+która będzie czas za {offset} sekund we {location}
+która będzie czas za {offset} sekundy
+która będzie czas za {offset} sekundy od teraz
+która będzie czas za {offset} sekundy od teraz w {location}
+która będzie czas za {offset} sekundy od teraz we {location}
+która będzie czas za {offset} sekundy w {location}
+która będzie czas za {offset} sekundy we {location}
 która będzie czas w {location} za {offset} godzin
 która będzie czas w {location} za {offset} godzin od teraz
 która będzie czas w {location} za {offset} godziny
@@ -2014,30 +1798,30 @@ która będzie czas w {location} za {offset} sekund
 która będzie czas w {location} za {offset} sekund od teraz
 która będzie czas w {location} za {offset} sekundy
 która będzie czas w {location} za {offset} sekundy od teraz
-która będzie czas we {location}  godzin
-która będzie czas we {location}  godzin od teraz
-która będzie czas we {location}  godziny
-która będzie czas we {location}  godziny od teraz
-która będzie czas we {location}  minut
-która będzie czas we {location}  minut od teraz
-która będzie czas we {location}  minuty
-która będzie czas we {location}  minuty od teraz
-która będzie czas we {location}  sekund
-która będzie czas we {location}  sekund od teraz
-która będzie czas we {location}  sekundy
-która będzie czas we {location}  sekundy od teraz
-która będzie czas we {location}  {offset} godzin
-która będzie czas we {location}  {offset} godzin od teraz
-która będzie czas we {location}  {offset} godziny
-która będzie czas we {location}  {offset} godziny od teraz
-która będzie czas we {location}  {offset} minut
-która będzie czas we {location}  {offset} minut od teraz
-która będzie czas we {location}  {offset} minuty
-która będzie czas we {location}  {offset} minuty od teraz
-która będzie czas we {location}  {offset} sekund
-która będzie czas we {location}  {offset} sekund od teraz
-która będzie czas we {location}  {offset} sekundy
-która będzie czas we {location}  {offset} sekundy od teraz
+która będzie czas w {location} za {offset} godzin
+która będzie czas w {location} za {offset} godzin od teraz
+która będzie czas w {location} za {offset} godziny
+która będzie czas w {location} za {offset} godziny od teraz
+która będzie czas w {location} za {offset} minut
+która będzie czas w {location} za {offset} minut od teraz
+która będzie czas w {location} za {offset} minuty
+która będzie czas w {location} za {offset} minuty od teraz
+która będzie czas w {location} za {offset} sekund
+która będzie czas w {location} za {offset} sekund od teraz
+która będzie czas w {location} za {offset} sekundy
+która będzie czas w {location} za {offset} sekundy od teraz
+która będzie czas we {location} za {offset} godzin
+która będzie czas we {location} za {offset} godzin od teraz
+która będzie czas we {location} za {offset} godziny
+która będzie czas we {location} za {offset} godziny od teraz
+która będzie czas we {location} za {offset} minut
+która będzie czas we {location} za {offset} minut od teraz
+która będzie czas we {location} za {offset} minuty
+która będzie czas we {location} za {offset} minuty od teraz
+która będzie czas we {location} za {offset} sekund
+która będzie czas we {location} za {offset} sekund od teraz
+która będzie czas we {location} za {offset} sekundy
+która będzie czas we {location} za {offset} sekundy od teraz
 która będzie czas we {location} za {offset} godzin
 która będzie czas we {location} za {offset} godzin od teraz
 która będzie czas we {location} za {offset} godziny
@@ -2086,66 +1870,42 @@ która będzie czas za {offset} sekundy od teraz w {location}
 która będzie czas za {offset} sekundy od teraz we {location}
 która będzie czas za {offset} sekundy w {location}
 która będzie czas za {offset} sekundy we {location}
-która będzie godzina  godzin
-która będzie godzina  godzin od teraz
-która będzie godzina  godzin od teraz w {location}
-która będzie godzina  godzin od teraz we {location}
-która będzie godzina  godzin w {location}
-która będzie godzina  godzin we {location}
-która będzie godzina  godziny
-która będzie godzina  godziny od teraz
-która będzie godzina  godziny od teraz w {location}
-która będzie godzina  godziny od teraz we {location}
-która będzie godzina  godziny w {location}
-która będzie godzina  godziny we {location}
-która będzie godzina  minut
-która będzie godzina  minut od teraz
-która będzie godzina  minut od teraz w {location}
-która będzie godzina  minut od teraz we {location}
-która będzie godzina  minut w {location}
-która będzie godzina  minut we {location}
-która będzie godzina  minuty
-która będzie godzina  minuty od teraz
-która będzie godzina  minuty od teraz w {location}
-która będzie godzina  minuty od teraz we {location}
-która będzie godzina  minuty w {location}
-która będzie godzina  minuty we {location}
-która będzie godzina  sekund
-która będzie godzina  sekund od teraz
-która będzie godzina  sekund od teraz w {location}
-która będzie godzina  sekund od teraz we {location}
-która będzie godzina  sekund w {location}
-która będzie godzina  sekund we {location}
-która będzie godzina  sekundy
-która będzie godzina  sekundy od teraz
-która będzie godzina  sekundy od teraz w {location}
-która będzie godzina  sekundy od teraz we {location}
-która będzie godzina  sekundy w {location}
-która będzie godzina  sekundy we {location}
-która będzie godzina w {location}  godzin
-która będzie godzina w {location}  godzin od teraz
-która będzie godzina w {location}  godziny
-która będzie godzina w {location}  godziny od teraz
-która będzie godzina w {location}  minut
-która będzie godzina w {location}  minut od teraz
-która będzie godzina w {location}  minuty
-która będzie godzina w {location}  minuty od teraz
-która będzie godzina w {location}  sekund
-która będzie godzina w {location}  sekund od teraz
-która będzie godzina w {location}  sekundy
-która będzie godzina w {location}  sekundy od teraz
-która będzie godzina w {location}  {offset} godzin
-która będzie godzina w {location}  {offset} godzin od teraz
-która będzie godzina w {location}  {offset} godziny
-która będzie godzina w {location}  {offset} godziny od teraz
-która będzie godzina w {location}  {offset} minut
-która będzie godzina w {location}  {offset} minut od teraz
-która będzie godzina w {location}  {offset} minuty
-która będzie godzina w {location}  {offset} minuty od teraz
-która będzie godzina w {location}  {offset} sekund
-która będzie godzina w {location}  {offset} sekund od teraz
-która będzie godzina w {location}  {offset} sekundy
-która będzie godzina w {location}  {offset} sekundy od teraz
+która będzie godzina za {offset} godzin
+która będzie godzina za {offset} godzin od teraz
+która będzie godzina za {offset} godzin od teraz w {location}
+która będzie godzina za {offset} godzin od teraz we {location}
+która będzie godzina za {offset} godzin w {location}
+która będzie godzina za {offset} godzin we {location}
+która będzie godzina za {offset} godziny
+która będzie godzina za {offset} godziny od teraz
+która będzie godzina za {offset} godziny od teraz w {location}
+która będzie godzina za {offset} godziny od teraz we {location}
+która będzie godzina za {offset} godziny w {location}
+która będzie godzina za {offset} godziny we {location}
+która będzie godzina za {offset} minut
+która będzie godzina za {offset} minut od teraz
+która będzie godzina za {offset} minut od teraz w {location}
+która będzie godzina za {offset} minut od teraz we {location}
+która będzie godzina za {offset} minut w {location}
+która będzie godzina za {offset} minut we {location}
+która będzie godzina za {offset} minuty
+która będzie godzina za {offset} minuty od teraz
+która będzie godzina za {offset} minuty od teraz w {location}
+która będzie godzina za {offset} minuty od teraz we {location}
+która będzie godzina za {offset} minuty w {location}
+która będzie godzina za {offset} minuty we {location}
+która będzie godzina za {offset} sekund
+która będzie godzina za {offset} sekund od teraz
+która będzie godzina za {offset} sekund od teraz w {location}
+która będzie godzina za {offset} sekund od teraz we {location}
+która będzie godzina za {offset} sekund w {location}
+która będzie godzina za {offset} sekund we {location}
+która będzie godzina za {offset} sekundy
+która będzie godzina za {offset} sekundy od teraz
+która będzie godzina za {offset} sekundy od teraz w {location}
+która będzie godzina za {offset} sekundy od teraz we {location}
+która będzie godzina za {offset} sekundy w {location}
+która będzie godzina za {offset} sekundy we {location}
 która będzie godzina w {location} za {offset} godzin
 która będzie godzina w {location} za {offset} godzin od teraz
 która będzie godzina w {location} za {offset} godziny
@@ -2158,30 +1918,30 @@ która będzie godzina w {location} za {offset} sekund
 która będzie godzina w {location} za {offset} sekund od teraz
 która będzie godzina w {location} za {offset} sekundy
 która będzie godzina w {location} za {offset} sekundy od teraz
-która będzie godzina we {location}  godzin
-która będzie godzina we {location}  godzin od teraz
-która będzie godzina we {location}  godziny
-która będzie godzina we {location}  godziny od teraz
-która będzie godzina we {location}  minut
-która będzie godzina we {location}  minut od teraz
-która będzie godzina we {location}  minuty
-która będzie godzina we {location}  minuty od teraz
-która będzie godzina we {location}  sekund
-która będzie godzina we {location}  sekund od teraz
-która będzie godzina we {location}  sekundy
-która będzie godzina we {location}  sekundy od teraz
-która będzie godzina we {location}  {offset} godzin
-która będzie godzina we {location}  {offset} godzin od teraz
-która będzie godzina we {location}  {offset} godziny
-która będzie godzina we {location}  {offset} godziny od teraz
-która będzie godzina we {location}  {offset} minut
-która będzie godzina we {location}  {offset} minut od teraz
-która będzie godzina we {location}  {offset} minuty
-która będzie godzina we {location}  {offset} minuty od teraz
-która będzie godzina we {location}  {offset} sekund
-która będzie godzina we {location}  {offset} sekund od teraz
-która będzie godzina we {location}  {offset} sekundy
-która będzie godzina we {location}  {offset} sekundy od teraz
+która będzie godzina w {location} za {offset} godzin
+która będzie godzina w {location} za {offset} godzin od teraz
+która będzie godzina w {location} za {offset} godziny
+która będzie godzina w {location} za {offset} godziny od teraz
+która będzie godzina w {location} za {offset} minut
+która będzie godzina w {location} za {offset} minut od teraz
+która będzie godzina w {location} za {offset} minuty
+która będzie godzina w {location} za {offset} minuty od teraz
+która będzie godzina w {location} za {offset} sekund
+która będzie godzina w {location} za {offset} sekund od teraz
+która będzie godzina w {location} za {offset} sekundy
+która będzie godzina w {location} za {offset} sekundy od teraz
+która będzie godzina we {location} za {offset} godzin
+która będzie godzina we {location} za {offset} godzin od teraz
+która będzie godzina we {location} za {offset} godziny
+która będzie godzina we {location} za {offset} godziny od teraz
+która będzie godzina we {location} za {offset} minut
+która będzie godzina we {location} za {offset} minut od teraz
+która będzie godzina we {location} za {offset} minuty
+która będzie godzina we {location} za {offset} minuty od teraz
+która będzie godzina we {location} za {offset} sekund
+która będzie godzina we {location} za {offset} sekund od teraz
+która będzie godzina we {location} za {offset} sekundy
+która będzie godzina we {location} za {offset} sekundy od teraz
 która będzie godzina we {location} za {offset} godzin
 która będzie godzina we {location} za {offset} godzin od teraz
 która będzie godzina we {location} za {offset} godziny
@@ -2230,42 +1990,6 @@ która będzie godzina za {offset} sekundy od teraz w {location}
 która będzie godzina za {offset} sekundy od teraz we {location}
 która będzie godzina za {offset} sekundy w {location}
 która będzie godzina za {offset} sekundy we {location}
-która czas będzie  godzin
-która czas będzie  godzin od teraz
-która czas będzie  godzin od teraz w {location}
-która czas będzie  godzin od teraz we {location}
-która czas będzie  godzin w {location}
-która czas będzie  godzin we {location}
-która czas będzie  godziny
-która czas będzie  godziny od teraz
-która czas będzie  godziny od teraz w {location}
-która czas będzie  godziny od teraz we {location}
-która czas będzie  godziny w {location}
-która czas będzie  godziny we {location}
-która czas będzie  minut
-która czas będzie  minut od teraz
-która czas będzie  minut od teraz w {location}
-która czas będzie  minut od teraz we {location}
-która czas będzie  minut w {location}
-która czas będzie  minut we {location}
-która czas będzie  minuty
-która czas będzie  minuty od teraz
-która czas będzie  minuty od teraz w {location}
-która czas będzie  minuty od teraz we {location}
-która czas będzie  minuty w {location}
-która czas będzie  minuty we {location}
-która czas będzie  sekund
-która czas będzie  sekund od teraz
-która czas będzie  sekund od teraz w {location}
-która czas będzie  sekund od teraz we {location}
-która czas będzie  sekund w {location}
-która czas będzie  sekund we {location}
-która czas będzie  sekundy
-która czas będzie  sekundy od teraz
-która czas będzie  sekundy od teraz w {location}
-która czas będzie  sekundy od teraz we {location}
-która czas będzie  sekundy w {location}
-która czas będzie  sekundy we {location}
 która czas będzie za {offset} godzin
 która czas będzie za {offset} godzin od teraz
 która czas będzie za {offset} godzin od teraz w {location}
@@ -2302,42 +2026,42 @@ która czas będzie za {offset} sekundy od teraz w {location}
 która czas będzie za {offset} sekundy od teraz we {location}
 która czas będzie za {offset} sekundy w {location}
 która czas będzie za {offset} sekundy we {location}
-która czas jest  godzin
-która czas jest  godzin od teraz
-która czas jest  godzin od teraz w {location}
-która czas jest  godzin od teraz we {location}
-która czas jest  godzin w {location}
-która czas jest  godzin we {location}
-która czas jest  godziny
-która czas jest  godziny od teraz
-która czas jest  godziny od teraz w {location}
-która czas jest  godziny od teraz we {location}
-która czas jest  godziny w {location}
-która czas jest  godziny we {location}
-która czas jest  minut
-która czas jest  minut od teraz
-która czas jest  minut od teraz w {location}
-która czas jest  minut od teraz we {location}
-która czas jest  minut w {location}
-która czas jest  minut we {location}
-która czas jest  minuty
-która czas jest  minuty od teraz
-która czas jest  minuty od teraz w {location}
-która czas jest  minuty od teraz we {location}
-która czas jest  minuty w {location}
-która czas jest  minuty we {location}
-która czas jest  sekund
-która czas jest  sekund od teraz
-która czas jest  sekund od teraz w {location}
-która czas jest  sekund od teraz we {location}
-która czas jest  sekund w {location}
-która czas jest  sekund we {location}
-która czas jest  sekundy
-która czas jest  sekundy od teraz
-która czas jest  sekundy od teraz w {location}
-która czas jest  sekundy od teraz we {location}
-która czas jest  sekundy w {location}
-która czas jest  sekundy we {location}
+która czas będzie za {offset} godzin
+która czas będzie za {offset} godzin od teraz
+która czas będzie za {offset} godzin od teraz w {location}
+która czas będzie za {offset} godzin od teraz we {location}
+która czas będzie za {offset} godzin w {location}
+która czas będzie za {offset} godzin we {location}
+która czas będzie za {offset} godziny
+która czas będzie za {offset} godziny od teraz
+która czas będzie za {offset} godziny od teraz w {location}
+która czas będzie za {offset} godziny od teraz we {location}
+która czas będzie za {offset} godziny w {location}
+która czas będzie za {offset} godziny we {location}
+która czas będzie za {offset} minut
+która czas będzie za {offset} minut od teraz
+która czas będzie za {offset} minut od teraz w {location}
+która czas będzie za {offset} minut od teraz we {location}
+która czas będzie za {offset} minut w {location}
+która czas będzie za {offset} minut we {location}
+która czas będzie za {offset} minuty
+która czas będzie za {offset} minuty od teraz
+która czas będzie za {offset} minuty od teraz w {location}
+która czas będzie za {offset} minuty od teraz we {location}
+która czas będzie za {offset} minuty w {location}
+która czas będzie za {offset} minuty we {location}
+która czas będzie za {offset} sekund
+która czas będzie za {offset} sekund od teraz
+która czas będzie za {offset} sekund od teraz w {location}
+która czas będzie za {offset} sekund od teraz we {location}
+która czas będzie za {offset} sekund w {location}
+która czas będzie za {offset} sekund we {location}
+która czas będzie za {offset} sekundy
+która czas będzie za {offset} sekundy od teraz
+która czas będzie za {offset} sekundy od teraz w {location}
+która czas będzie za {offset} sekundy od teraz we {location}
+która czas będzie za {offset} sekundy w {location}
+która czas będzie za {offset} sekundy we {location}
 która czas jest za {offset} godzin
 która czas jest za {offset} godzin od teraz
 która czas jest za {offset} godzin od teraz w {location}
@@ -2374,42 +2098,42 @@ która czas jest za {offset} sekundy od teraz w {location}
 która czas jest za {offset} sekundy od teraz we {location}
 która czas jest za {offset} sekundy w {location}
 która czas jest za {offset} sekundy we {location}
-która godzina będzie  godzin
-która godzina będzie  godzin od teraz
-która godzina będzie  godzin od teraz w {location}
-która godzina będzie  godzin od teraz we {location}
-która godzina będzie  godzin w {location}
-która godzina będzie  godzin we {location}
-która godzina będzie  godziny
-która godzina będzie  godziny od teraz
-która godzina będzie  godziny od teraz w {location}
-która godzina będzie  godziny od teraz we {location}
-która godzina będzie  godziny w {location}
-która godzina będzie  godziny we {location}
-która godzina będzie  minut
-która godzina będzie  minut od teraz
-która godzina będzie  minut od teraz w {location}
-która godzina będzie  minut od teraz we {location}
-która godzina będzie  minut w {location}
-która godzina będzie  minut we {location}
-która godzina będzie  minuty
-która godzina będzie  minuty od teraz
-która godzina będzie  minuty od teraz w {location}
-która godzina będzie  minuty od teraz we {location}
-która godzina będzie  minuty w {location}
-która godzina będzie  minuty we {location}
-która godzina będzie  sekund
-która godzina będzie  sekund od teraz
-która godzina będzie  sekund od teraz w {location}
-która godzina będzie  sekund od teraz we {location}
-która godzina będzie  sekund w {location}
-która godzina będzie  sekund we {location}
-która godzina będzie  sekundy
-która godzina będzie  sekundy od teraz
-która godzina będzie  sekundy od teraz w {location}
-która godzina będzie  sekundy od teraz we {location}
-która godzina będzie  sekundy w {location}
-która godzina będzie  sekundy we {location}
+która czas jest za {offset} godzin
+która czas jest za {offset} godzin od teraz
+która czas jest za {offset} godzin od teraz w {location}
+która czas jest za {offset} godzin od teraz we {location}
+która czas jest za {offset} godzin w {location}
+która czas jest za {offset} godzin we {location}
+która czas jest za {offset} godziny
+która czas jest za {offset} godziny od teraz
+która czas jest za {offset} godziny od teraz w {location}
+która czas jest za {offset} godziny od teraz we {location}
+która czas jest za {offset} godziny w {location}
+która czas jest za {offset} godziny we {location}
+która czas jest za {offset} minut
+która czas jest za {offset} minut od teraz
+która czas jest za {offset} minut od teraz w {location}
+która czas jest za {offset} minut od teraz we {location}
+która czas jest za {offset} minut w {location}
+która czas jest za {offset} minut we {location}
+która czas jest za {offset} minuty
+która czas jest za {offset} minuty od teraz
+która czas jest za {offset} minuty od teraz w {location}
+która czas jest za {offset} minuty od teraz we {location}
+która czas jest za {offset} minuty w {location}
+która czas jest za {offset} minuty we {location}
+która czas jest za {offset} sekund
+która czas jest za {offset} sekund od teraz
+która czas jest za {offset} sekund od teraz w {location}
+która czas jest za {offset} sekund od teraz we {location}
+która czas jest za {offset} sekund w {location}
+która czas jest za {offset} sekund we {location}
+która czas jest za {offset} sekundy
+która czas jest za {offset} sekundy od teraz
+która czas jest za {offset} sekundy od teraz w {location}
+która czas jest za {offset} sekundy od teraz we {location}
+która czas jest za {offset} sekundy w {location}
+która czas jest za {offset} sekundy we {location}
 która godzina będzie za {offset} godzin
 która godzina będzie za {offset} godzin od teraz
 która godzina będzie za {offset} godzin od teraz w {location}
@@ -2446,42 +2170,42 @@ która godzina będzie za {offset} sekundy od teraz w {location}
 która godzina będzie za {offset} sekundy od teraz we {location}
 która godzina będzie za {offset} sekundy w {location}
 która godzina będzie za {offset} sekundy we {location}
-która godzina jest  godzin
-która godzina jest  godzin od teraz
-która godzina jest  godzin od teraz w {location}
-która godzina jest  godzin od teraz we {location}
-która godzina jest  godzin w {location}
-która godzina jest  godzin we {location}
-która godzina jest  godziny
-która godzina jest  godziny od teraz
-która godzina jest  godziny od teraz w {location}
-która godzina jest  godziny od teraz we {location}
-która godzina jest  godziny w {location}
-która godzina jest  godziny we {location}
-która godzina jest  minut
-która godzina jest  minut od teraz
-która godzina jest  minut od teraz w {location}
-która godzina jest  minut od teraz we {location}
-która godzina jest  minut w {location}
-która godzina jest  minut we {location}
-która godzina jest  minuty
-która godzina jest  minuty od teraz
-która godzina jest  minuty od teraz w {location}
-która godzina jest  minuty od teraz we {location}
-która godzina jest  minuty w {location}
-która godzina jest  minuty we {location}
-która godzina jest  sekund
-która godzina jest  sekund od teraz
-która godzina jest  sekund od teraz w {location}
-która godzina jest  sekund od teraz we {location}
-która godzina jest  sekund w {location}
-która godzina jest  sekund we {location}
-która godzina jest  sekundy
-która godzina jest  sekundy od teraz
-która godzina jest  sekundy od teraz w {location}
-która godzina jest  sekundy od teraz we {location}
-która godzina jest  sekundy w {location}
-która godzina jest  sekundy we {location}
+która godzina będzie za {offset} godzin
+która godzina będzie za {offset} godzin od teraz
+która godzina będzie za {offset} godzin od teraz w {location}
+która godzina będzie za {offset} godzin od teraz we {location}
+która godzina będzie za {offset} godzin w {location}
+która godzina będzie za {offset} godzin we {location}
+która godzina będzie za {offset} godziny
+która godzina będzie za {offset} godziny od teraz
+która godzina będzie za {offset} godziny od teraz w {location}
+która godzina będzie za {offset} godziny od teraz we {location}
+która godzina będzie za {offset} godziny w {location}
+która godzina będzie za {offset} godziny we {location}
+która godzina będzie za {offset} minut
+która godzina będzie za {offset} minut od teraz
+która godzina będzie za {offset} minut od teraz w {location}
+która godzina będzie za {offset} minut od teraz we {location}
+która godzina będzie za {offset} minut w {location}
+która godzina będzie za {offset} minut we {location}
+która godzina będzie za {offset} minuty
+która godzina będzie za {offset} minuty od teraz
+która godzina będzie za {offset} minuty od teraz w {location}
+która godzina będzie za {offset} minuty od teraz we {location}
+która godzina będzie za {offset} minuty w {location}
+która godzina będzie za {offset} minuty we {location}
+która godzina będzie za {offset} sekund
+która godzina będzie za {offset} sekund od teraz
+która godzina będzie za {offset} sekund od teraz w {location}
+która godzina będzie za {offset} sekund od teraz we {location}
+która godzina będzie za {offset} sekund w {location}
+która godzina będzie za {offset} sekund we {location}
+która godzina będzie za {offset} sekundy
+która godzina będzie za {offset} sekundy od teraz
+która godzina będzie za {offset} sekundy od teraz w {location}
+która godzina będzie za {offset} sekundy od teraz we {location}
+która godzina będzie za {offset} sekundy w {location}
+która godzina będzie za {offset} sekundy we {location}
 która godzina jest za {offset} godzin
 która godzina jest za {offset} godzin od teraz
 która godzina jest za {offset} godzin od teraz w {location}
@@ -2518,66 +2242,78 @@ która godzina jest za {offset} sekundy od teraz w {location}
 która godzina jest za {offset} sekundy od teraz we {location}
 która godzina jest za {offset} sekundy w {location}
 która godzina jest za {offset} sekundy we {location}
-która jest czas  godzin
-która jest czas  godzin od teraz
-która jest czas  godzin od teraz w {location}
-która jest czas  godzin od teraz we {location}
-która jest czas  godzin w {location}
-która jest czas  godzin we {location}
-która jest czas  godziny
-która jest czas  godziny od teraz
-która jest czas  godziny od teraz w {location}
-która jest czas  godziny od teraz we {location}
-która jest czas  godziny w {location}
-która jest czas  godziny we {location}
-która jest czas  minut
-która jest czas  minut od teraz
-która jest czas  minut od teraz w {location}
-która jest czas  minut od teraz we {location}
-która jest czas  minut w {location}
-która jest czas  minut we {location}
-która jest czas  minuty
-która jest czas  minuty od teraz
-która jest czas  minuty od teraz w {location}
-która jest czas  minuty od teraz we {location}
-która jest czas  minuty w {location}
-która jest czas  minuty we {location}
-która jest czas  sekund
-która jest czas  sekund od teraz
-która jest czas  sekund od teraz w {location}
-która jest czas  sekund od teraz we {location}
-która jest czas  sekund w {location}
-która jest czas  sekund we {location}
-która jest czas  sekundy
-która jest czas  sekundy od teraz
-która jest czas  sekundy od teraz w {location}
-która jest czas  sekundy od teraz we {location}
-która jest czas  sekundy w {location}
-która jest czas  sekundy we {location}
-która jest czas w {location}  godzin
-która jest czas w {location}  godzin od teraz
-która jest czas w {location}  godziny
-która jest czas w {location}  godziny od teraz
-która jest czas w {location}  minut
-która jest czas w {location}  minut od teraz
-która jest czas w {location}  minuty
-która jest czas w {location}  minuty od teraz
-która jest czas w {location}  sekund
-która jest czas w {location}  sekund od teraz
-która jest czas w {location}  sekundy
-która jest czas w {location}  sekundy od teraz
-która jest czas w {location}  {offset} godzin
-która jest czas w {location}  {offset} godzin od teraz
-która jest czas w {location}  {offset} godziny
-która jest czas w {location}  {offset} godziny od teraz
-która jest czas w {location}  {offset} minut
-która jest czas w {location}  {offset} minut od teraz
-która jest czas w {location}  {offset} minuty
-która jest czas w {location}  {offset} minuty od teraz
-która jest czas w {location}  {offset} sekund
-która jest czas w {location}  {offset} sekund od teraz
-która jest czas w {location}  {offset} sekundy
-która jest czas w {location}  {offset} sekundy od teraz
+która godzina jest za {offset} godzin
+która godzina jest za {offset} godzin od teraz
+która godzina jest za {offset} godzin od teraz w {location}
+która godzina jest za {offset} godzin od teraz we {location}
+która godzina jest za {offset} godzin w {location}
+która godzina jest za {offset} godzin we {location}
+która godzina jest za {offset} godziny
+która godzina jest za {offset} godziny od teraz
+która godzina jest za {offset} godziny od teraz w {location}
+która godzina jest za {offset} godziny od teraz we {location}
+która godzina jest za {offset} godziny w {location}
+która godzina jest za {offset} godziny we {location}
+która godzina jest za {offset} minut
+która godzina jest za {offset} minut od teraz
+która godzina jest za {offset} minut od teraz w {location}
+która godzina jest za {offset} minut od teraz we {location}
+która godzina jest za {offset} minut w {location}
+która godzina jest za {offset} minut we {location}
+która godzina jest za {offset} minuty
+która godzina jest za {offset} minuty od teraz
+która godzina jest za {offset} minuty od teraz w {location}
+która godzina jest za {offset} minuty od teraz we {location}
+która godzina jest za {offset} minuty w {location}
+która godzina jest za {offset} minuty we {location}
+która godzina jest za {offset} sekund
+która godzina jest za {offset} sekund od teraz
+która godzina jest za {offset} sekund od teraz w {location}
+która godzina jest za {offset} sekund od teraz we {location}
+która godzina jest za {offset} sekund w {location}
+która godzina jest za {offset} sekund we {location}
+która godzina jest za {offset} sekundy
+która godzina jest za {offset} sekundy od teraz
+która godzina jest za {offset} sekundy od teraz w {location}
+która godzina jest za {offset} sekundy od teraz we {location}
+która godzina jest za {offset} sekundy w {location}
+która godzina jest za {offset} sekundy we {location}
+która jest czas za {offset} godzin
+która jest czas za {offset} godzin od teraz
+która jest czas za {offset} godzin od teraz w {location}
+która jest czas za {offset} godzin od teraz we {location}
+która jest czas za {offset} godzin w {location}
+która jest czas za {offset} godzin we {location}
+która jest czas za {offset} godziny
+która jest czas za {offset} godziny od teraz
+która jest czas za {offset} godziny od teraz w {location}
+która jest czas za {offset} godziny od teraz we {location}
+która jest czas za {offset} godziny w {location}
+która jest czas za {offset} godziny we {location}
+która jest czas za {offset} minut
+która jest czas za {offset} minut od teraz
+która jest czas za {offset} minut od teraz w {location}
+która jest czas za {offset} minut od teraz we {location}
+która jest czas za {offset} minut w {location}
+która jest czas za {offset} minut we {location}
+która jest czas za {offset} minuty
+która jest czas za {offset} minuty od teraz
+która jest czas za {offset} minuty od teraz w {location}
+która jest czas za {offset} minuty od teraz we {location}
+która jest czas za {offset} minuty w {location}
+która jest czas za {offset} minuty we {location}
+która jest czas za {offset} sekund
+która jest czas za {offset} sekund od teraz
+która jest czas za {offset} sekund od teraz w {location}
+która jest czas za {offset} sekund od teraz we {location}
+która jest czas za {offset} sekund w {location}
+która jest czas za {offset} sekund we {location}
+która jest czas za {offset} sekundy
+która jest czas za {offset} sekundy od teraz
+która jest czas za {offset} sekundy od teraz w {location}
+która jest czas za {offset} sekundy od teraz we {location}
+która jest czas za {offset} sekundy w {location}
+która jest czas za {offset} sekundy we {location}
 która jest czas w {location} za {offset} godzin
 która jest czas w {location} za {offset} godzin od teraz
 która jest czas w {location} za {offset} godziny
@@ -2590,30 +2326,30 @@ która jest czas w {location} za {offset} sekund
 która jest czas w {location} za {offset} sekund od teraz
 która jest czas w {location} za {offset} sekundy
 która jest czas w {location} za {offset} sekundy od teraz
-która jest czas we {location}  godzin
-która jest czas we {location}  godzin od teraz
-która jest czas we {location}  godziny
-która jest czas we {location}  godziny od teraz
-która jest czas we {location}  minut
-która jest czas we {location}  minut od teraz
-która jest czas we {location}  minuty
-która jest czas we {location}  minuty od teraz
-która jest czas we {location}  sekund
-która jest czas we {location}  sekund od teraz
-która jest czas we {location}  sekundy
-która jest czas we {location}  sekundy od teraz
-która jest czas we {location}  {offset} godzin
-która jest czas we {location}  {offset} godzin od teraz
-która jest czas we {location}  {offset} godziny
-która jest czas we {location}  {offset} godziny od teraz
-która jest czas we {location}  {offset} minut
-która jest czas we {location}  {offset} minut od teraz
-która jest czas we {location}  {offset} minuty
-która jest czas we {location}  {offset} minuty od teraz
-która jest czas we {location}  {offset} sekund
-która jest czas we {location}  {offset} sekund od teraz
-która jest czas we {location}  {offset} sekundy
-która jest czas we {location}  {offset} sekundy od teraz
+która jest czas w {location} za {offset} godzin
+która jest czas w {location} za {offset} godzin od teraz
+która jest czas w {location} za {offset} godziny
+która jest czas w {location} za {offset} godziny od teraz
+która jest czas w {location} za {offset} minut
+która jest czas w {location} za {offset} minut od teraz
+która jest czas w {location} za {offset} minuty
+która jest czas w {location} za {offset} minuty od teraz
+która jest czas w {location} za {offset} sekund
+która jest czas w {location} za {offset} sekund od teraz
+która jest czas w {location} za {offset} sekundy
+która jest czas w {location} za {offset} sekundy od teraz
+która jest czas we {location} za {offset} godzin
+która jest czas we {location} za {offset} godzin od teraz
+która jest czas we {location} za {offset} godziny
+która jest czas we {location} za {offset} godziny od teraz
+która jest czas we {location} za {offset} minut
+która jest czas we {location} za {offset} minut od teraz
+która jest czas we {location} za {offset} minuty
+która jest czas we {location} za {offset} minuty od teraz
+która jest czas we {location} za {offset} sekund
+która jest czas we {location} za {offset} sekund od teraz
+która jest czas we {location} za {offset} sekundy
+która jest czas we {location} za {offset} sekundy od teraz
 która jest czas we {location} za {offset} godzin
 która jest czas we {location} za {offset} godzin od teraz
 która jest czas we {location} za {offset} godziny
@@ -2662,66 +2398,42 @@ która jest czas za {offset} sekundy od teraz w {location}
 która jest czas za {offset} sekundy od teraz we {location}
 która jest czas za {offset} sekundy w {location}
 która jest czas za {offset} sekundy we {location}
-która jest godzina  godzin
-która jest godzina  godzin od teraz
-która jest godzina  godzin od teraz w {location}
-która jest godzina  godzin od teraz we {location}
-która jest godzina  godzin w {location}
-która jest godzina  godzin we {location}
-która jest godzina  godziny
-która jest godzina  godziny od teraz
-która jest godzina  godziny od teraz w {location}
-która jest godzina  godziny od teraz we {location}
-która jest godzina  godziny w {location}
-która jest godzina  godziny we {location}
-która jest godzina  minut
-która jest godzina  minut od teraz
-która jest godzina  minut od teraz w {location}
-która jest godzina  minut od teraz we {location}
-która jest godzina  minut w {location}
-która jest godzina  minut we {location}
-która jest godzina  minuty
-która jest godzina  minuty od teraz
-która jest godzina  minuty od teraz w {location}
-która jest godzina  minuty od teraz we {location}
-która jest godzina  minuty w {location}
-która jest godzina  minuty we {location}
-która jest godzina  sekund
-która jest godzina  sekund od teraz
-która jest godzina  sekund od teraz w {location}
-która jest godzina  sekund od teraz we {location}
-która jest godzina  sekund w {location}
-która jest godzina  sekund we {location}
-która jest godzina  sekundy
-która jest godzina  sekundy od teraz
-która jest godzina  sekundy od teraz w {location}
-która jest godzina  sekundy od teraz we {location}
-która jest godzina  sekundy w {location}
-która jest godzina  sekundy we {location}
-która jest godzina w {location}  godzin
-która jest godzina w {location}  godzin od teraz
-która jest godzina w {location}  godziny
-która jest godzina w {location}  godziny od teraz
-która jest godzina w {location}  minut
-która jest godzina w {location}  minut od teraz
-która jest godzina w {location}  minuty
-która jest godzina w {location}  minuty od teraz
-która jest godzina w {location}  sekund
-która jest godzina w {location}  sekund od teraz
-która jest godzina w {location}  sekundy
-która jest godzina w {location}  sekundy od teraz
-która jest godzina w {location}  {offset} godzin
-która jest godzina w {location}  {offset} godzin od teraz
-która jest godzina w {location}  {offset} godziny
-która jest godzina w {location}  {offset} godziny od teraz
-która jest godzina w {location}  {offset} minut
-która jest godzina w {location}  {offset} minut od teraz
-która jest godzina w {location}  {offset} minuty
-która jest godzina w {location}  {offset} minuty od teraz
-która jest godzina w {location}  {offset} sekund
-która jest godzina w {location}  {offset} sekund od teraz
-która jest godzina w {location}  {offset} sekundy
-która jest godzina w {location}  {offset} sekundy od teraz
+która jest godzina za {offset} godzin
+która jest godzina za {offset} godzin od teraz
+która jest godzina za {offset} godzin od teraz w {location}
+która jest godzina za {offset} godzin od teraz we {location}
+która jest godzina za {offset} godzin w {location}
+która jest godzina za {offset} godzin we {location}
+która jest godzina za {offset} godziny
+która jest godzina za {offset} godziny od teraz
+która jest godzina za {offset} godziny od teraz w {location}
+która jest godzina za {offset} godziny od teraz we {location}
+która jest godzina za {offset} godziny w {location}
+która jest godzina za {offset} godziny we {location}
+która jest godzina za {offset} minut
+która jest godzina za {offset} minut od teraz
+która jest godzina za {offset} minut od teraz w {location}
+która jest godzina za {offset} minut od teraz we {location}
+która jest godzina za {offset} minut w {location}
+która jest godzina za {offset} minut we {location}
+która jest godzina za {offset} minuty
+która jest godzina za {offset} minuty od teraz
+która jest godzina za {offset} minuty od teraz w {location}
+która jest godzina za {offset} minuty od teraz we {location}
+która jest godzina za {offset} minuty w {location}
+która jest godzina za {offset} minuty we {location}
+która jest godzina za {offset} sekund
+która jest godzina za {offset} sekund od teraz
+która jest godzina za {offset} sekund od teraz w {location}
+która jest godzina za {offset} sekund od teraz we {location}
+która jest godzina za {offset} sekund w {location}
+która jest godzina za {offset} sekund we {location}
+która jest godzina za {offset} sekundy
+która jest godzina za {offset} sekundy od teraz
+która jest godzina za {offset} sekundy od teraz w {location}
+która jest godzina za {offset} sekundy od teraz we {location}
+która jest godzina za {offset} sekundy w {location}
+która jest godzina za {offset} sekundy we {location}
 która jest godzina w {location} za {offset} godzin
 która jest godzina w {location} za {offset} godzin od teraz
 która jest godzina w {location} za {offset} godziny
@@ -2734,30 +2446,30 @@ która jest godzina w {location} za {offset} sekund
 która jest godzina w {location} za {offset} sekund od teraz
 która jest godzina w {location} za {offset} sekundy
 która jest godzina w {location} za {offset} sekundy od teraz
-która jest godzina we {location}  godzin
-która jest godzina we {location}  godzin od teraz
-która jest godzina we {location}  godziny
-która jest godzina we {location}  godziny od teraz
-która jest godzina we {location}  minut
-która jest godzina we {location}  minut od teraz
-która jest godzina we {location}  minuty
-która jest godzina we {location}  minuty od teraz
-która jest godzina we {location}  sekund
-która jest godzina we {location}  sekund od teraz
-która jest godzina we {location}  sekundy
-która jest godzina we {location}  sekundy od teraz
-która jest godzina we {location}  {offset} godzin
-która jest godzina we {location}  {offset} godzin od teraz
-która jest godzina we {location}  {offset} godziny
-która jest godzina we {location}  {offset} godziny od teraz
-która jest godzina we {location}  {offset} minut
-która jest godzina we {location}  {offset} minut od teraz
-która jest godzina we {location}  {offset} minuty
-która jest godzina we {location}  {offset} minuty od teraz
-która jest godzina we {location}  {offset} sekund
-która jest godzina we {location}  {offset} sekund od teraz
-która jest godzina we {location}  {offset} sekundy
-która jest godzina we {location}  {offset} sekundy od teraz
+która jest godzina w {location} za {offset} godzin
+która jest godzina w {location} za {offset} godzin od teraz
+która jest godzina w {location} za {offset} godziny
+która jest godzina w {location} za {offset} godziny od teraz
+która jest godzina w {location} za {offset} minut
+która jest godzina w {location} za {offset} minut od teraz
+która jest godzina w {location} za {offset} minuty
+która jest godzina w {location} za {offset} minuty od teraz
+która jest godzina w {location} za {offset} sekund
+która jest godzina w {location} za {offset} sekund od teraz
+która jest godzina w {location} za {offset} sekundy
+która jest godzina w {location} za {offset} sekundy od teraz
+która jest godzina we {location} za {offset} godzin
+która jest godzina we {location} za {offset} godzin od teraz
+która jest godzina we {location} za {offset} godziny
+która jest godzina we {location} za {offset} godziny od teraz
+która jest godzina we {location} za {offset} minut
+która jest godzina we {location} za {offset} minut od teraz
+która jest godzina we {location} za {offset} minuty
+która jest godzina we {location} za {offset} minuty od teraz
+która jest godzina we {location} za {offset} sekund
+która jest godzina we {location} za {offset} sekund od teraz
+która jest godzina we {location} za {offset} sekundy
+która jest godzina we {location} za {offset} sekundy od teraz
 która jest godzina we {location} za {offset} godzin
 która jest godzina we {location} za {offset} godzin od teraz
 która jest godzina we {location} za {offset} godziny
@@ -3022,294 +2734,198 @@ o której miną {offset} sekundy od teraz w {location}
 o której miną {offset} sekundy od teraz we {location}
 o której miną {offset} sekundy w {location}
 o której miną {offset} sekundy we {location}
-podaj czas  godzin
-podaj czas  godzin od teraz
-podaj czas  godzin od teraz w {location
-podaj czas  godzin od teraz we {location
-podaj czas  godzin w {location
-podaj czas  godzin we {location
-podaj czas  godziny
-podaj czas  godziny od teraz
-podaj czas  godziny od teraz w {location
-podaj czas  godziny od teraz we {location
-podaj czas  godziny w {location
-podaj czas  godziny we {location
-podaj czas  minut
-podaj czas  minut od teraz
-podaj czas  minut od teraz w {location
-podaj czas  minut od teraz we {location
-podaj czas  minut w {location
-podaj czas  minut we {location
-podaj czas  minuty
-podaj czas  minuty od teraz
-podaj czas  minuty od teraz w {location
-podaj czas  minuty od teraz we {location
-podaj czas  minuty w {location
-podaj czas  minuty we {location
-podaj czas  sekund
-podaj czas  sekund od teraz
-podaj czas  sekund od teraz w {location
-podaj czas  sekund od teraz we {location
-podaj czas  sekund w {location
-podaj czas  sekund we {location
-podaj czas  sekundy
-podaj czas  sekundy od teraz
-podaj czas  sekundy od teraz w {location
-podaj czas  sekundy od teraz we {location
-podaj czas  sekundy w {location
-podaj czas  sekundy we {location
 podaj czas za {offset} godzin
 podaj czas za {offset} godzin od teraz
-podaj czas za {offset} godzin od teraz w {location
-podaj czas za {offset} godzin od teraz we {location
-podaj czas za {offset} godzin w {location
-podaj czas za {offset} godzin we {location
+podaj czas za {offset} godzin od teraz w {location}
+podaj czas za {offset} godzin od teraz we {location}
+podaj czas za {offset} godzin w {location}
+podaj czas za {offset} godzin we {location}
 podaj czas za {offset} godziny
 podaj czas za {offset} godziny od teraz
-podaj czas za {offset} godziny od teraz w {location
-podaj czas za {offset} godziny od teraz we {location
-podaj czas za {offset} godziny w {location
-podaj czas za {offset} godziny we {location
+podaj czas za {offset} godziny od teraz w {location}
+podaj czas za {offset} godziny od teraz we {location}
+podaj czas za {offset} godziny w {location}
+podaj czas za {offset} godziny we {location}
 podaj czas za {offset} minut
 podaj czas za {offset} minut od teraz
-podaj czas za {offset} minut od teraz w {location
-podaj czas za {offset} minut od teraz we {location
-podaj czas za {offset} minut w {location
-podaj czas za {offset} minut we {location
+podaj czas za {offset} minut od teraz w {location}
+podaj czas za {offset} minut od teraz we {location}
+podaj czas za {offset} minut w {location}
+podaj czas za {offset} minut we {location}
 podaj czas za {offset} minuty
 podaj czas za {offset} minuty od teraz
-podaj czas za {offset} minuty od teraz w {location
-podaj czas za {offset} minuty od teraz we {location
-podaj czas za {offset} minuty w {location
-podaj czas za {offset} minuty we {location
+podaj czas za {offset} minuty od teraz w {location}
+podaj czas za {offset} minuty od teraz we {location}
+podaj czas za {offset} minuty w {location}
+podaj czas za {offset} minuty we {location}
 podaj czas za {offset} sekund
 podaj czas za {offset} sekund od teraz
-podaj czas za {offset} sekund od teraz w {location
-podaj czas za {offset} sekund od teraz we {location
-podaj czas za {offset} sekund w {location
-podaj czas za {offset} sekund we {location
+podaj czas za {offset} sekund od teraz w {location}
+podaj czas za {offset} sekund od teraz we {location}
+podaj czas za {offset} sekund w {location}
+podaj czas za {offset} sekund we {location}
 podaj czas za {offset} sekundy
 podaj czas za {offset} sekundy od teraz
-podaj czas za {offset} sekundy od teraz w {location
-podaj czas za {offset} sekundy od teraz we {location
-podaj czas za {offset} sekundy w {location
-podaj czas za {offset} sekundy we {location
-podaj godzinę  godzin
-podaj godzinę  godzin od teraz
-podaj godzinę  godzin od teraz w {location
-podaj godzinę  godzin od teraz we {location
-podaj godzinę  godzin w {location
-podaj godzinę  godzin we {location
-podaj godzinę  godziny
-podaj godzinę  godziny od teraz
-podaj godzinę  godziny od teraz w {location
-podaj godzinę  godziny od teraz we {location
-podaj godzinę  godziny w {location
-podaj godzinę  godziny we {location
-podaj godzinę  minut
-podaj godzinę  minut od teraz
-podaj godzinę  minut od teraz w {location
-podaj godzinę  minut od teraz we {location
-podaj godzinę  minut w {location
-podaj godzinę  minut we {location
-podaj godzinę  minuty
-podaj godzinę  minuty od teraz
-podaj godzinę  minuty od teraz w {location
-podaj godzinę  minuty od teraz we {location
-podaj godzinę  minuty w {location
-podaj godzinę  minuty we {location
-podaj godzinę  sekund
-podaj godzinę  sekund od teraz
-podaj godzinę  sekund od teraz w {location
-podaj godzinę  sekund od teraz we {location
-podaj godzinę  sekund w {location
-podaj godzinę  sekund we {location
-podaj godzinę  sekundy
-podaj godzinę  sekundy od teraz
-podaj godzinę  sekundy od teraz w {location
-podaj godzinę  sekundy od teraz we {location
-podaj godzinę  sekundy w {location
-podaj godzinę  sekundy we {location
+podaj czas za {offset} sekundy od teraz w {location}
+podaj czas za {offset} sekundy od teraz we {location}
+podaj czas za {offset} sekundy w {location}
+podaj czas za {offset} sekundy we {location}
+podaj czas za {offset} godzin
+podaj czas za {offset} godzin od teraz
+podaj czas za {offset} godziny
+podaj czas za {offset} godziny od teraz
+podaj czas za {offset} minut
+podaj czas za {offset} minut od teraz
+podaj czas za {offset} minuty
+podaj czas za {offset} minuty od teraz
+podaj czas za {offset} sekund
+podaj czas za {offset} sekund od teraz
+podaj czas za {offset} sekundy
+podaj czas za {offset} sekundy od teraz
 podaj godzinę za {offset} godzin
 podaj godzinę za {offset} godzin od teraz
-podaj godzinę za {offset} godzin od teraz w {location
-podaj godzinę za {offset} godzin od teraz we {location
-podaj godzinę za {offset} godzin w {location
-podaj godzinę za {offset} godzin we {location
+podaj godzinę za {offset} godzin od teraz w {location}
+podaj godzinę za {offset} godzin od teraz we {location}
+podaj godzinę za {offset} godzin w {location}
+podaj godzinę za {offset} godzin we {location}
 podaj godzinę za {offset} godziny
 podaj godzinę za {offset} godziny od teraz
-podaj godzinę za {offset} godziny od teraz w {location
-podaj godzinę za {offset} godziny od teraz we {location
-podaj godzinę za {offset} godziny w {location
-podaj godzinę za {offset} godziny we {location
+podaj godzinę za {offset} godziny od teraz w {location}
+podaj godzinę za {offset} godziny od teraz we {location}
+podaj godzinę za {offset} godziny w {location}
+podaj godzinę za {offset} godziny we {location}
 podaj godzinę za {offset} minut
 podaj godzinę za {offset} minut od teraz
-podaj godzinę za {offset} minut od teraz w {location
-podaj godzinę za {offset} minut od teraz we {location
-podaj godzinę za {offset} minut w {location
-podaj godzinę za {offset} minut we {location
+podaj godzinę za {offset} minut od teraz w {location}
+podaj godzinę za {offset} minut od teraz we {location}
+podaj godzinę za {offset} minut w {location}
+podaj godzinę za {offset} minut we {location}
 podaj godzinę za {offset} minuty
 podaj godzinę za {offset} minuty od teraz
-podaj godzinę za {offset} minuty od teraz w {location
-podaj godzinę za {offset} minuty od teraz we {location
-podaj godzinę za {offset} minuty w {location
-podaj godzinę za {offset} minuty we {location
+podaj godzinę za {offset} minuty od teraz w {location}
+podaj godzinę za {offset} minuty od teraz we {location}
+podaj godzinę za {offset} minuty w {location}
+podaj godzinę za {offset} minuty we {location}
 podaj godzinę za {offset} sekund
 podaj godzinę za {offset} sekund od teraz
-podaj godzinę za {offset} sekund od teraz w {location
-podaj godzinę za {offset} sekund od teraz we {location
-podaj godzinę za {offset} sekund w {location
-podaj godzinę za {offset} sekund we {location
+podaj godzinę za {offset} sekund od teraz w {location}
+podaj godzinę za {offset} sekund od teraz we {location}
+podaj godzinę za {offset} sekund w {location}
+podaj godzinę za {offset} sekund we {location}
 podaj godzinę za {offset} sekundy
 podaj godzinę za {offset} sekundy od teraz
-podaj godzinę za {offset} sekundy od teraz w {location
-podaj godzinę za {offset} sekundy od teraz we {location
-podaj godzinę za {offset} sekundy w {location
-podaj godzinę za {offset} sekundy we {location
-powiedz czas  godzin
-powiedz czas  godzin od teraz
-powiedz czas  godzin od teraz w {location
-powiedz czas  godzin od teraz we {location
-powiedz czas  godzin w {location
-powiedz czas  godzin we {location
-powiedz czas  godziny
-powiedz czas  godziny od teraz
-powiedz czas  godziny od teraz w {location
-powiedz czas  godziny od teraz we {location
-powiedz czas  godziny w {location
-powiedz czas  godziny we {location
-powiedz czas  minut
-powiedz czas  minut od teraz
-powiedz czas  minut od teraz w {location
-powiedz czas  minut od teraz we {location
-powiedz czas  minut w {location
-powiedz czas  minut we {location
-powiedz czas  minuty
-powiedz czas  minuty od teraz
-powiedz czas  minuty od teraz w {location
-powiedz czas  minuty od teraz we {location
-powiedz czas  minuty w {location
-powiedz czas  minuty we {location
-powiedz czas  sekund
-powiedz czas  sekund od teraz
-powiedz czas  sekund od teraz w {location
-powiedz czas  sekund od teraz we {location
-powiedz czas  sekund w {location
-powiedz czas  sekund we {location
-powiedz czas  sekundy
-powiedz czas  sekundy od teraz
-powiedz czas  sekundy od teraz w {location
-powiedz czas  sekundy od teraz we {location
-powiedz czas  sekundy w {location
-powiedz czas  sekundy we {location
+podaj godzinę za {offset} sekundy od teraz w {location}
+podaj godzinę za {offset} sekundy od teraz we {location}
+podaj godzinę za {offset} sekundy w {location}
+podaj godzinę za {offset} sekundy we {location}
+podaj godzinę za {offset} godzin
+podaj godzinę za {offset} godzin od teraz
+podaj godzinę za {offset} godziny
+podaj godzinę za {offset} godziny od teraz
+podaj godzinę za {offset} minut
+podaj godzinę za {offset} minut od teraz
+podaj godzinę za {offset} minuty
+podaj godzinę za {offset} minuty od teraz
+podaj godzinę za {offset} sekund
+podaj godzinę za {offset} sekund od teraz
+podaj godzinę za {offset} sekundy
+podaj godzinę za {offset} sekundy od teraz
 powiedz czas za {offset} godzin
 powiedz czas za {offset} godzin od teraz
-powiedz czas za {offset} godzin od teraz w {location
-powiedz czas za {offset} godzin od teraz we {location
-powiedz czas za {offset} godzin w {location
-powiedz czas za {offset} godzin we {location
+powiedz czas za {offset} godzin od teraz w {location}
+powiedz czas za {offset} godzin od teraz we {location}
+powiedz czas za {offset} godzin w {location}
+powiedz czas za {offset} godzin we {location}
 powiedz czas za {offset} godziny
 powiedz czas za {offset} godziny od teraz
-powiedz czas za {offset} godziny od teraz w {location
-powiedz czas za {offset} godziny od teraz we {location
-powiedz czas za {offset} godziny w {location
-powiedz czas za {offset} godziny we {location
+powiedz czas za {offset} godziny od teraz w {location}
+powiedz czas za {offset} godziny od teraz we {location}
+powiedz czas za {offset} godziny w {location}
+powiedz czas za {offset} godziny we {location}
 powiedz czas za {offset} minut
 powiedz czas za {offset} minut od teraz
-powiedz czas za {offset} minut od teraz w {location
-powiedz czas za {offset} minut od teraz we {location
-powiedz czas za {offset} minut w {location
-powiedz czas za {offset} minut we {location
+powiedz czas za {offset} minut od teraz w {location}
+powiedz czas za {offset} minut od teraz we {location}
+powiedz czas za {offset} minut w {location}
+powiedz czas za {offset} minut we {location}
 powiedz czas za {offset} minuty
 powiedz czas za {offset} minuty od teraz
-powiedz czas za {offset} minuty od teraz w {location
-powiedz czas za {offset} minuty od teraz we {location
-powiedz czas za {offset} minuty w {location
-powiedz czas za {offset} minuty we {location
+powiedz czas za {offset} minuty od teraz w {location}
+powiedz czas za {offset} minuty od teraz we {location}
+powiedz czas za {offset} minuty w {location}
+powiedz czas za {offset} minuty we {location}
 powiedz czas za {offset} sekund
 powiedz czas za {offset} sekund od teraz
-powiedz czas za {offset} sekund od teraz w {location
-powiedz czas za {offset} sekund od teraz we {location
-powiedz czas za {offset} sekund w {location
-powiedz czas za {offset} sekund we {location
+powiedz czas za {offset} sekund od teraz w {location}
+powiedz czas za {offset} sekund od teraz we {location}
+powiedz czas za {offset} sekund w {location}
+powiedz czas za {offset} sekund we {location}
 powiedz czas za {offset} sekundy
 powiedz czas za {offset} sekundy od teraz
-powiedz czas za {offset} sekundy od teraz w {location
-powiedz czas za {offset} sekundy od teraz we {location
-powiedz czas za {offset} sekundy w {location
-powiedz czas za {offset} sekundy we {location
-powiedz godzinę  godzin
-powiedz godzinę  godzin od teraz
-powiedz godzinę  godzin od teraz w {location
-powiedz godzinę  godzin od teraz we {location
-powiedz godzinę  godzin w {location
-powiedz godzinę  godzin we {location
-powiedz godzinę  godziny
-powiedz godzinę  godziny od teraz
-powiedz godzinę  godziny od teraz w {location
-powiedz godzinę  godziny od teraz we {location
-powiedz godzinę  godziny w {location
-powiedz godzinę  godziny we {location
-powiedz godzinę  minut
-powiedz godzinę  minut od teraz
-powiedz godzinę  minut od teraz w {location
-powiedz godzinę  minut od teraz we {location
-powiedz godzinę  minut w {location
-powiedz godzinę  minut we {location
-powiedz godzinę  minuty
-powiedz godzinę  minuty od teraz
-powiedz godzinę  minuty od teraz w {location
-powiedz godzinę  minuty od teraz we {location
-powiedz godzinę  minuty w {location
-powiedz godzinę  minuty we {location
-powiedz godzinę  sekund
-powiedz godzinę  sekund od teraz
-powiedz godzinę  sekund od teraz w {location
-powiedz godzinę  sekund od teraz we {location
-powiedz godzinę  sekund w {location
-powiedz godzinę  sekund we {location
-powiedz godzinę  sekundy
-powiedz godzinę  sekundy od teraz
-powiedz godzinę  sekundy od teraz w {location
-powiedz godzinę  sekundy od teraz we {location
-powiedz godzinę  sekundy w {location
-powiedz godzinę  sekundy we {location
+powiedz czas za {offset} sekundy od teraz w {location}
+powiedz czas za {offset} sekundy od teraz we {location}
+powiedz czas za {offset} sekundy w {location}
+powiedz czas za {offset} sekundy we {location}
+powiedz czas za {offset} godzin
+powiedz czas za {offset} godzin od teraz
+powiedz czas za {offset} godziny
+powiedz czas za {offset} godziny od teraz
+powiedz czas za {offset} minut
+powiedz czas za {offset} minut od teraz
+powiedz czas za {offset} minuty
+powiedz czas za {offset} minuty od teraz
+powiedz czas za {offset} sekund
+powiedz czas za {offset} sekund od teraz
+powiedz czas za {offset} sekundy
+powiedz czas za {offset} sekundy od teraz
 powiedz godzinę za {offset} godzin
 powiedz godzinę za {offset} godzin od teraz
-powiedz godzinę za {offset} godzin od teraz w {location
-powiedz godzinę za {offset} godzin od teraz we {location
-powiedz godzinę za {offset} godzin w {location
-powiedz godzinę za {offset} godzin we {location
+powiedz godzinę za {offset} godzin od teraz w {location}
+powiedz godzinę za {offset} godzin od teraz we {location}
+powiedz godzinę za {offset} godzin w {location}
+powiedz godzinę za {offset} godzin we {location}
 powiedz godzinę za {offset} godziny
 powiedz godzinę za {offset} godziny od teraz
-powiedz godzinę za {offset} godziny od teraz w {location
-powiedz godzinę za {offset} godziny od teraz we {location
-powiedz godzinę za {offset} godziny w {location
-powiedz godzinę za {offset} godziny we {location
+powiedz godzinę za {offset} godziny od teraz w {location}
+powiedz godzinę za {offset} godziny od teraz we {location}
+powiedz godzinę za {offset} godziny w {location}
+powiedz godzinę za {offset} godziny we {location}
 powiedz godzinę za {offset} minut
 powiedz godzinę za {offset} minut od teraz
-powiedz godzinę za {offset} minut od teraz w {location
-powiedz godzinę za {offset} minut od teraz we {location
-powiedz godzinę za {offset} minut w {location
-powiedz godzinę za {offset} minut we {location
+powiedz godzinę za {offset} minut od teraz w {location}
+powiedz godzinę za {offset} minut od teraz we {location}
+powiedz godzinę za {offset} minut w {location}
+powiedz godzinę za {offset} minut we {location}
 powiedz godzinę za {offset} minuty
 powiedz godzinę za {offset} minuty od teraz
-powiedz godzinę za {offset} minuty od teraz w {location
-powiedz godzinę za {offset} minuty od teraz we {location
-powiedz godzinę za {offset} minuty w {location
-powiedz godzinę za {offset} minuty we {location
+powiedz godzinę za {offset} minuty od teraz w {location}
+powiedz godzinę za {offset} minuty od teraz we {location}
+powiedz godzinę za {offset} minuty w {location}
+powiedz godzinę za {offset} minuty we {location}
 powiedz godzinę za {offset} sekund
 powiedz godzinę za {offset} sekund od teraz
-powiedz godzinę za {offset} sekund od teraz w {location
-powiedz godzinę za {offset} sekund od teraz we {location
-powiedz godzinę za {offset} sekund w {location
-powiedz godzinę za {offset} sekund we {location
+powiedz godzinę za {offset} sekund od teraz w {location}
+powiedz godzinę za {offset} sekund od teraz we {location}
+powiedz godzinę za {offset} sekund w {location}
+powiedz godzinę za {offset} sekund we {location}
 powiedz godzinę za {offset} sekundy
 powiedz godzinę za {offset} sekundy od teraz
-powiedz godzinę za {offset} sekundy od teraz w {location
-powiedz godzinę za {offset} sekundy od teraz we {location
-powiedz godzinę za {offset} sekundy w {location
-powiedz godzinę za {offset} sekundy we {location
+powiedz godzinę za {offset} sekundy od teraz w {location}
+powiedz godzinę za {offset} sekundy od teraz we {location}
+powiedz godzinę za {offset} sekundy w {location}
+powiedz godzinę za {offset} sekundy we {location}
+powiedz godzinę za {offset} godzin
+powiedz godzinę za {offset} godzin od teraz
+powiedz godzinę za {offset} godziny
+powiedz godzinę za {offset} godziny od teraz
+powiedz godzinę za {offset} minut
+powiedz godzinę za {offset} minut od teraz
+powiedz godzinę za {offset} minuty
+powiedz godzinę za {offset} minuty od teraz
+powiedz godzinę za {offset} sekund
+powiedz godzinę za {offset} sekund od teraz
+powiedz godzinę za {offset} sekundy
+powiedz godzinę za {offset} sekundy od teraz
 sekund jaka będzie czas
 sekund jaka będzie czas w {location}
 sekund jaka będzie czas we {location}
@@ -3454,18 +3070,18 @@ sekundy od teraz która jest czas we {location}
 sekundy od teraz która jest godzina
 sekundy od teraz która jest godzina w {location}
 sekundy od teraz która jest godzina we {location}
-w {location} jaka będzie czas  godzin
-w {location} jaka będzie czas  godzin od teraz
-w {location} jaka będzie czas  godziny
-w {location} jaka będzie czas  godziny od teraz
-w {location} jaka będzie czas  minut
-w {location} jaka będzie czas  minut od teraz
-w {location} jaka będzie czas  minuty
-w {location} jaka będzie czas  minuty od teraz
-w {location} jaka będzie czas  sekund
-w {location} jaka będzie czas  sekund od teraz
-w {location} jaka będzie czas  sekundy
-w {location} jaka będzie czas  sekundy od teraz
+w {location} jaka będzie czas za {offset} godzin
+w {location} jaka będzie czas za {offset} godzin od teraz
+w {location} jaka będzie czas za {offset} godziny
+w {location} jaka będzie czas za {offset} godziny od teraz
+w {location} jaka będzie czas za {offset} minut
+w {location} jaka będzie czas za {offset} minut od teraz
+w {location} jaka będzie czas za {offset} minuty
+w {location} jaka będzie czas za {offset} minuty od teraz
+w {location} jaka będzie czas za {offset} sekund
+w {location} jaka będzie czas za {offset} sekund od teraz
+w {location} jaka będzie czas za {offset} sekundy
+w {location} jaka będzie czas za {offset} sekundy od teraz
 w {location} jaka będzie czas  {offset} godzin
 w {location} jaka będzie czas  {offset} godzin od teraz
 w {location} jaka będzie czas  {offset} godziny
@@ -3490,18 +3106,18 @@ w {location} jaka będzie czas za {offset} sekund
 w {location} jaka będzie czas za {offset} sekund od teraz
 w {location} jaka będzie czas za {offset} sekundy
 w {location} jaka będzie czas za {offset} sekundy od teraz
-w {location} jaka będzie godzina  godzin
-w {location} jaka będzie godzina  godzin od teraz
-w {location} jaka będzie godzina  godziny
-w {location} jaka będzie godzina  godziny od teraz
-w {location} jaka będzie godzina  minut
-w {location} jaka będzie godzina  minut od teraz
-w {location} jaka będzie godzina  minuty
-w {location} jaka będzie godzina  minuty od teraz
-w {location} jaka będzie godzina  sekund
-w {location} jaka będzie godzina  sekund od teraz
-w {location} jaka będzie godzina  sekundy
-w {location} jaka będzie godzina  sekundy od teraz
+w {location} jaka będzie godzina za {offset} godzin
+w {location} jaka będzie godzina za {offset} godzin od teraz
+w {location} jaka będzie godzina za {offset} godziny
+w {location} jaka będzie godzina za {offset} godziny od teraz
+w {location} jaka będzie godzina za {offset} minut
+w {location} jaka będzie godzina za {offset} minut od teraz
+w {location} jaka będzie godzina za {offset} minuty
+w {location} jaka będzie godzina za {offset} minuty od teraz
+w {location} jaka będzie godzina za {offset} sekund
+w {location} jaka będzie godzina za {offset} sekund od teraz
+w {location} jaka będzie godzina za {offset} sekundy
+w {location} jaka będzie godzina za {offset} sekundy od teraz
 w {location} jaka będzie godzina  {offset} godzin
 w {location} jaka będzie godzina  {offset} godzin od teraz
 w {location} jaka będzie godzina  {offset} godziny
@@ -3526,18 +3142,18 @@ w {location} jaka będzie godzina za {offset} sekund
 w {location} jaka będzie godzina za {offset} sekund od teraz
 w {location} jaka będzie godzina za {offset} sekundy
 w {location} jaka będzie godzina za {offset} sekundy od teraz
-w {location} jaka jest czas  godzin
-w {location} jaka jest czas  godzin od teraz
-w {location} jaka jest czas  godziny
-w {location} jaka jest czas  godziny od teraz
-w {location} jaka jest czas  minut
-w {location} jaka jest czas  minut od teraz
-w {location} jaka jest czas  minuty
-w {location} jaka jest czas  minuty od teraz
-w {location} jaka jest czas  sekund
-w {location} jaka jest czas  sekund od teraz
-w {location} jaka jest czas  sekundy
-w {location} jaka jest czas  sekundy od teraz
+w {location} jaka jest czas za {offset} godzin
+w {location} jaka jest czas za {offset} godzin od teraz
+w {location} jaka jest czas za {offset} godziny
+w {location} jaka jest czas za {offset} godziny od teraz
+w {location} jaka jest czas za {offset} minut
+w {location} jaka jest czas za {offset} minut od teraz
+w {location} jaka jest czas za {offset} minuty
+w {location} jaka jest czas za {offset} minuty od teraz
+w {location} jaka jest czas za {offset} sekund
+w {location} jaka jest czas za {offset} sekund od teraz
+w {location} jaka jest czas za {offset} sekundy
+w {location} jaka jest czas za {offset} sekundy od teraz
 w {location} jaka jest czas  {offset} godzin
 w {location} jaka jest czas  {offset} godzin od teraz
 w {location} jaka jest czas  {offset} godziny
@@ -3562,18 +3178,18 @@ w {location} jaka jest czas za {offset} sekund
 w {location} jaka jest czas za {offset} sekund od teraz
 w {location} jaka jest czas za {offset} sekundy
 w {location} jaka jest czas za {offset} sekundy od teraz
-w {location} jaka jest godzina  godzin
-w {location} jaka jest godzina  godzin od teraz
-w {location} jaka jest godzina  godziny
-w {location} jaka jest godzina  godziny od teraz
-w {location} jaka jest godzina  minut
-w {location} jaka jest godzina  minut od teraz
-w {location} jaka jest godzina  minuty
-w {location} jaka jest godzina  minuty od teraz
-w {location} jaka jest godzina  sekund
-w {location} jaka jest godzina  sekund od teraz
-w {location} jaka jest godzina  sekundy
-w {location} jaka jest godzina  sekundy od teraz
+w {location} jaka jest godzina za {offset} godzin
+w {location} jaka jest godzina za {offset} godzin od teraz
+w {location} jaka jest godzina za {offset} godziny
+w {location} jaka jest godzina za {offset} godziny od teraz
+w {location} jaka jest godzina za {offset} minut
+w {location} jaka jest godzina za {offset} minut od teraz
+w {location} jaka jest godzina za {offset} minuty
+w {location} jaka jest godzina za {offset} minuty od teraz
+w {location} jaka jest godzina za {offset} sekund
+w {location} jaka jest godzina za {offset} sekund od teraz
+w {location} jaka jest godzina za {offset} sekundy
+w {location} jaka jest godzina za {offset} sekundy od teraz
 w {location} jaka jest godzina  {offset} godzin
 w {location} jaka jest godzina  {offset} godzin od teraz
 w {location} jaka jest godzina  {offset} godziny
@@ -3598,18 +3214,18 @@ w {location} jaka jest godzina za {offset} sekund
 w {location} jaka jest godzina za {offset} sekund od teraz
 w {location} jaka jest godzina za {offset} sekundy
 w {location} jaka jest godzina za {offset} sekundy od teraz
-w {location} jaki będzie czas  godzin
-w {location} jaki będzie czas  godzin od teraz
-w {location} jaki będzie czas  godziny
-w {location} jaki będzie czas  godziny od teraz
-w {location} jaki będzie czas  minut
-w {location} jaki będzie czas  minut od teraz
-w {location} jaki będzie czas  minuty
-w {location} jaki będzie czas  minuty od teraz
-w {location} jaki będzie czas  sekund
-w {location} jaki będzie czas  sekund od teraz
-w {location} jaki będzie czas  sekundy
-w {location} jaki będzie czas  sekundy od teraz
+w {location} jaki będzie czas za {offset} godzin
+w {location} jaki będzie czas za {offset} godzin od teraz
+w {location} jaki będzie czas za {offset} godziny
+w {location} jaki będzie czas za {offset} godziny od teraz
+w {location} jaki będzie czas za {offset} minut
+w {location} jaki będzie czas za {offset} minut od teraz
+w {location} jaki będzie czas za {offset} minuty
+w {location} jaki będzie czas za {offset} minuty od teraz
+w {location} jaki będzie czas za {offset} sekund
+w {location} jaki będzie czas za {offset} sekund od teraz
+w {location} jaki będzie czas za {offset} sekundy
+w {location} jaki będzie czas za {offset} sekundy od teraz
 w {location} jaki będzie czas  {offset} godzin
 w {location} jaki będzie czas  {offset} godzin od teraz
 w {location} jaki będzie czas  {offset} godziny
@@ -3634,18 +3250,18 @@ w {location} jaki będzie czas za {offset} sekund
 w {location} jaki będzie czas za {offset} sekund od teraz
 w {location} jaki będzie czas za {offset} sekundy
 w {location} jaki będzie czas za {offset} sekundy od teraz
-w {location} jaki będzie godzina  godzin
-w {location} jaki będzie godzina  godzin od teraz
-w {location} jaki będzie godzina  godziny
-w {location} jaki będzie godzina  godziny od teraz
-w {location} jaki będzie godzina  minut
-w {location} jaki będzie godzina  minut od teraz
-w {location} jaki będzie godzina  minuty
-w {location} jaki będzie godzina  minuty od teraz
-w {location} jaki będzie godzina  sekund
-w {location} jaki będzie godzina  sekund od teraz
-w {location} jaki będzie godzina  sekundy
-w {location} jaki będzie godzina  sekundy od teraz
+w {location} jaki będzie godzina za {offset} godzin
+w {location} jaki będzie godzina za {offset} godzin od teraz
+w {location} jaki będzie godzina za {offset} godziny
+w {location} jaki będzie godzina za {offset} godziny od teraz
+w {location} jaki będzie godzina za {offset} minut
+w {location} jaki będzie godzina za {offset} minut od teraz
+w {location} jaki będzie godzina za {offset} minuty
+w {location} jaki będzie godzina za {offset} minuty od teraz
+w {location} jaki będzie godzina za {offset} sekund
+w {location} jaki będzie godzina za {offset} sekund od teraz
+w {location} jaki będzie godzina za {offset} sekundy
+w {location} jaki będzie godzina za {offset} sekundy od teraz
 w {location} jaki będzie godzina  {offset} godzin
 w {location} jaki będzie godzina  {offset} godzin od teraz
 w {location} jaki będzie godzina  {offset} godziny
@@ -3670,18 +3286,18 @@ w {location} jaki będzie godzina za {offset} sekund
 w {location} jaki będzie godzina za {offset} sekund od teraz
 w {location} jaki będzie godzina za {offset} sekundy
 w {location} jaki będzie godzina za {offset} sekundy od teraz
-w {location} jaki jest czas  godzin
-w {location} jaki jest czas  godzin od teraz
-w {location} jaki jest czas  godziny
-w {location} jaki jest czas  godziny od teraz
-w {location} jaki jest czas  minut
-w {location} jaki jest czas  minut od teraz
-w {location} jaki jest czas  minuty
-w {location} jaki jest czas  minuty od teraz
-w {location} jaki jest czas  sekund
-w {location} jaki jest czas  sekund od teraz
-w {location} jaki jest czas  sekundy
-w {location} jaki jest czas  sekundy od teraz
+w {location} jaki jest czas za {offset} godzin
+w {location} jaki jest czas za {offset} godzin od teraz
+w {location} jaki jest czas za {offset} godziny
+w {location} jaki jest czas za {offset} godziny od teraz
+w {location} jaki jest czas za {offset} minut
+w {location} jaki jest czas za {offset} minut od teraz
+w {location} jaki jest czas za {offset} minuty
+w {location} jaki jest czas za {offset} minuty od teraz
+w {location} jaki jest czas za {offset} sekund
+w {location} jaki jest czas za {offset} sekund od teraz
+w {location} jaki jest czas za {offset} sekundy
+w {location} jaki jest czas za {offset} sekundy od teraz
 w {location} jaki jest czas  {offset} godzin
 w {location} jaki jest czas  {offset} godzin od teraz
 w {location} jaki jest czas  {offset} godziny
@@ -3706,18 +3322,18 @@ w {location} jaki jest czas za {offset} sekund
 w {location} jaki jest czas za {offset} sekund od teraz
 w {location} jaki jest czas za {offset} sekundy
 w {location} jaki jest czas za {offset} sekundy od teraz
-w {location} jaki jest godzina  godzin
-w {location} jaki jest godzina  godzin od teraz
-w {location} jaki jest godzina  godziny
-w {location} jaki jest godzina  godziny od teraz
-w {location} jaki jest godzina  minut
-w {location} jaki jest godzina  minut od teraz
-w {location} jaki jest godzina  minuty
-w {location} jaki jest godzina  minuty od teraz
-w {location} jaki jest godzina  sekund
-w {location} jaki jest godzina  sekund od teraz
-w {location} jaki jest godzina  sekundy
-w {location} jaki jest godzina  sekundy od teraz
+w {location} jaki jest godzina za {offset} godzin
+w {location} jaki jest godzina za {offset} godzin od teraz
+w {location} jaki jest godzina za {offset} godziny
+w {location} jaki jest godzina za {offset} godziny od teraz
+w {location} jaki jest godzina za {offset} minut
+w {location} jaki jest godzina za {offset} minut od teraz
+w {location} jaki jest godzina za {offset} minuty
+w {location} jaki jest godzina za {offset} minuty od teraz
+w {location} jaki jest godzina za {offset} sekund
+w {location} jaki jest godzina za {offset} sekund od teraz
+w {location} jaki jest godzina za {offset} sekundy
+w {location} jaki jest godzina za {offset} sekundy od teraz
 w {location} jaki jest godzina  {offset} godzin
 w {location} jaki jest godzina  {offset} godzin od teraz
 w {location} jaki jest godzina  {offset} godziny
@@ -3742,18 +3358,18 @@ w {location} jaki jest godzina za {offset} sekund
 w {location} jaki jest godzina za {offset} sekund od teraz
 w {location} jaki jest godzina za {offset} sekundy
 w {location} jaki jest godzina za {offset} sekundy od teraz
-w {location} która będzie czas  godzin
-w {location} która będzie czas  godzin od teraz
-w {location} która będzie czas  godziny
-w {location} która będzie czas  godziny od teraz
-w {location} która będzie czas  minut
-w {location} która będzie czas  minut od teraz
-w {location} która będzie czas  minuty
-w {location} która będzie czas  minuty od teraz
-w {location} która będzie czas  sekund
-w {location} która będzie czas  sekund od teraz
-w {location} która będzie czas  sekundy
-w {location} która będzie czas  sekundy od teraz
+w {location} która będzie czas za {offset} godzin
+w {location} która będzie czas za {offset} godzin od teraz
+w {location} która będzie czas za {offset} godziny
+w {location} która będzie czas za {offset} godziny od teraz
+w {location} która będzie czas za {offset} minut
+w {location} która będzie czas za {offset} minut od teraz
+w {location} która będzie czas za {offset} minuty
+w {location} która będzie czas za {offset} minuty od teraz
+w {location} która będzie czas za {offset} sekund
+w {location} która będzie czas za {offset} sekund od teraz
+w {location} która będzie czas za {offset} sekundy
+w {location} która będzie czas za {offset} sekundy od teraz
 w {location} która będzie czas  {offset} godzin
 w {location} która będzie czas  {offset} godzin od teraz
 w {location} która będzie czas  {offset} godziny
@@ -3778,18 +3394,18 @@ w {location} która będzie czas za {offset} sekund
 w {location} która będzie czas za {offset} sekund od teraz
 w {location} która będzie czas za {offset} sekundy
 w {location} która będzie czas za {offset} sekundy od teraz
-w {location} która będzie godzina  godzin
-w {location} która będzie godzina  godzin od teraz
-w {location} która będzie godzina  godziny
-w {location} która będzie godzina  godziny od teraz
-w {location} która będzie godzina  minut
-w {location} która będzie godzina  minut od teraz
-w {location} która będzie godzina  minuty
-w {location} która będzie godzina  minuty od teraz
-w {location} która będzie godzina  sekund
-w {location} która będzie godzina  sekund od teraz
-w {location} która będzie godzina  sekundy
-w {location} która będzie godzina  sekundy od teraz
+w {location} która będzie godzina za {offset} godzin
+w {location} która będzie godzina za {offset} godzin od teraz
+w {location} która będzie godzina za {offset} godziny
+w {location} która będzie godzina za {offset} godziny od teraz
+w {location} która będzie godzina za {offset} minut
+w {location} która będzie godzina za {offset} minut od teraz
+w {location} która będzie godzina za {offset} minuty
+w {location} która będzie godzina za {offset} minuty od teraz
+w {location} która będzie godzina za {offset} sekund
+w {location} która będzie godzina za {offset} sekund od teraz
+w {location} która będzie godzina za {offset} sekundy
+w {location} która będzie godzina za {offset} sekundy od teraz
 w {location} która będzie godzina  {offset} godzin
 w {location} która będzie godzina  {offset} godzin od teraz
 w {location} która będzie godzina  {offset} godziny
@@ -3814,18 +3430,18 @@ w {location} która będzie godzina za {offset} sekund
 w {location} która będzie godzina za {offset} sekund od teraz
 w {location} która będzie godzina za {offset} sekundy
 w {location} która będzie godzina za {offset} sekundy od teraz
-w {location} która jest czas  godzin
-w {location} która jest czas  godzin od teraz
-w {location} która jest czas  godziny
-w {location} która jest czas  godziny od teraz
-w {location} która jest czas  minut
-w {location} która jest czas  minut od teraz
-w {location} która jest czas  minuty
-w {location} która jest czas  minuty od teraz
-w {location} która jest czas  sekund
-w {location} która jest czas  sekund od teraz
-w {location} która jest czas  sekundy
-w {location} która jest czas  sekundy od teraz
+w {location} która jest czas za {offset} godzin
+w {location} która jest czas za {offset} godzin od teraz
+w {location} która jest czas za {offset} godziny
+w {location} która jest czas za {offset} godziny od teraz
+w {location} która jest czas za {offset} minut
+w {location} która jest czas za {offset} minut od teraz
+w {location} która jest czas za {offset} minuty
+w {location} która jest czas za {offset} minuty od teraz
+w {location} która jest czas za {offset} sekund
+w {location} która jest czas za {offset} sekund od teraz
+w {location} która jest czas za {offset} sekundy
+w {location} która jest czas za {offset} sekundy od teraz
 w {location} która jest czas  {offset} godzin
 w {location} która jest czas  {offset} godzin od teraz
 w {location} która jest czas  {offset} godziny
@@ -3850,18 +3466,18 @@ w {location} która jest czas za {offset} sekund
 w {location} która jest czas za {offset} sekund od teraz
 w {location} która jest czas za {offset} sekundy
 w {location} która jest czas za {offset} sekundy od teraz
-w {location} która jest godzina  godzin
-w {location} która jest godzina  godzin od teraz
-w {location} która jest godzina  godziny
-w {location} która jest godzina  godziny od teraz
-w {location} która jest godzina  minut
-w {location} która jest godzina  minut od teraz
-w {location} która jest godzina  minuty
-w {location} która jest godzina  minuty od teraz
-w {location} która jest godzina  sekund
-w {location} która jest godzina  sekund od teraz
-w {location} która jest godzina  sekundy
-w {location} która jest godzina  sekundy od teraz
+w {location} która jest godzina za {offset} godzin
+w {location} która jest godzina za {offset} godzin od teraz
+w {location} która jest godzina za {offset} godziny
+w {location} która jest godzina za {offset} godziny od teraz
+w {location} która jest godzina za {offset} minut
+w {location} która jest godzina za {offset} minut od teraz
+w {location} która jest godzina za {offset} minuty
+w {location} która jest godzina za {offset} minuty od teraz
+w {location} która jest godzina za {offset} sekund
+w {location} która jest godzina za {offset} sekund od teraz
+w {location} która jest godzina za {offset} sekundy
+w {location} która jest godzina za {offset} sekundy od teraz
 w {location} która jest godzina  {offset} godzin
 w {location} która jest godzina  {offset} godzin od teraz
 w {location} która jest godzina  {offset} godziny
@@ -3886,18 +3502,18 @@ w {location} która jest godzina za {offset} sekund
 w {location} która jest godzina za {offset} sekund od teraz
 w {location} która jest godzina za {offset} sekundy
 w {location} która jest godzina za {offset} sekundy od teraz
-we {location} jaka będzie czas  godzin
-we {location} jaka będzie czas  godzin od teraz
-we {location} jaka będzie czas  godziny
-we {location} jaka będzie czas  godziny od teraz
-we {location} jaka będzie czas  minut
-we {location} jaka będzie czas  minut od teraz
-we {location} jaka będzie czas  minuty
-we {location} jaka będzie czas  minuty od teraz
-we {location} jaka będzie czas  sekund
-we {location} jaka będzie czas  sekund od teraz
-we {location} jaka będzie czas  sekundy
-we {location} jaka będzie czas  sekundy od teraz
+we {location} jaka będzie czas za {offset} godzin
+we {location} jaka będzie czas za {offset} godzin od teraz
+we {location} jaka będzie czas za {offset} godziny
+we {location} jaka będzie czas za {offset} godziny od teraz
+we {location} jaka będzie czas za {offset} minut
+we {location} jaka będzie czas za {offset} minut od teraz
+we {location} jaka będzie czas za {offset} minuty
+we {location} jaka będzie czas za {offset} minuty od teraz
+we {location} jaka będzie czas za {offset} sekund
+we {location} jaka będzie czas za {offset} sekund od teraz
+we {location} jaka będzie czas za {offset} sekundy
+we {location} jaka będzie czas za {offset} sekundy od teraz
 we {location} jaka będzie czas  {offset} godzin
 we {location} jaka będzie czas  {offset} godzin od teraz
 we {location} jaka będzie czas  {offset} godziny
@@ -3922,18 +3538,18 @@ we {location} jaka będzie czas za {offset} sekund
 we {location} jaka będzie czas za {offset} sekund od teraz
 we {location} jaka będzie czas za {offset} sekundy
 we {location} jaka będzie czas za {offset} sekundy od teraz
-we {location} jaka będzie godzina  godzin
-we {location} jaka będzie godzina  godzin od teraz
-we {location} jaka będzie godzina  godziny
-we {location} jaka będzie godzina  godziny od teraz
-we {location} jaka będzie godzina  minut
-we {location} jaka będzie godzina  minut od teraz
-we {location} jaka będzie godzina  minuty
-we {location} jaka będzie godzina  minuty od teraz
-we {location} jaka będzie godzina  sekund
-we {location} jaka będzie godzina  sekund od teraz
-we {location} jaka będzie godzina  sekundy
-we {location} jaka będzie godzina  sekundy od teraz
+we {location} jaka będzie godzina za {offset} godzin
+we {location} jaka będzie godzina za {offset} godzin od teraz
+we {location} jaka będzie godzina za {offset} godziny
+we {location} jaka będzie godzina za {offset} godziny od teraz
+we {location} jaka będzie godzina za {offset} minut
+we {location} jaka będzie godzina za {offset} minut od teraz
+we {location} jaka będzie godzina za {offset} minuty
+we {location} jaka będzie godzina za {offset} minuty od teraz
+we {location} jaka będzie godzina za {offset} sekund
+we {location} jaka będzie godzina za {offset} sekund od teraz
+we {location} jaka będzie godzina za {offset} sekundy
+we {location} jaka będzie godzina za {offset} sekundy od teraz
 we {location} jaka będzie godzina  {offset} godzin
 we {location} jaka będzie godzina  {offset} godzin od teraz
 we {location} jaka będzie godzina  {offset} godziny
@@ -3958,18 +3574,18 @@ we {location} jaka będzie godzina za {offset} sekund
 we {location} jaka będzie godzina za {offset} sekund od teraz
 we {location} jaka będzie godzina za {offset} sekundy
 we {location} jaka będzie godzina za {offset} sekundy od teraz
-we {location} jaka jest czas  godzin
-we {location} jaka jest czas  godzin od teraz
-we {location} jaka jest czas  godziny
-we {location} jaka jest czas  godziny od teraz
-we {location} jaka jest czas  minut
-we {location} jaka jest czas  minut od teraz
-we {location} jaka jest czas  minuty
-we {location} jaka jest czas  minuty od teraz
-we {location} jaka jest czas  sekund
-we {location} jaka jest czas  sekund od teraz
-we {location} jaka jest czas  sekundy
-we {location} jaka jest czas  sekundy od teraz
+we {location} jaka jest czas za {offset} godzin
+we {location} jaka jest czas za {offset} godzin od teraz
+we {location} jaka jest czas za {offset} godziny
+we {location} jaka jest czas za {offset} godziny od teraz
+we {location} jaka jest czas za {offset} minut
+we {location} jaka jest czas za {offset} minut od teraz
+we {location} jaka jest czas za {offset} minuty
+we {location} jaka jest czas za {offset} minuty od teraz
+we {location} jaka jest czas za {offset} sekund
+we {location} jaka jest czas za {offset} sekund od teraz
+we {location} jaka jest czas za {offset} sekundy
+we {location} jaka jest czas za {offset} sekundy od teraz
 we {location} jaka jest czas  {offset} godzin
 we {location} jaka jest czas  {offset} godzin od teraz
 we {location} jaka jest czas  {offset} godziny
@@ -3994,18 +3610,18 @@ we {location} jaka jest czas za {offset} sekund
 we {location} jaka jest czas za {offset} sekund od teraz
 we {location} jaka jest czas za {offset} sekundy
 we {location} jaka jest czas za {offset} sekundy od teraz
-we {location} jaka jest godzina  godzin
-we {location} jaka jest godzina  godzin od teraz
-we {location} jaka jest godzina  godziny
-we {location} jaka jest godzina  godziny od teraz
-we {location} jaka jest godzina  minut
-we {location} jaka jest godzina  minut od teraz
-we {location} jaka jest godzina  minuty
-we {location} jaka jest godzina  minuty od teraz
-we {location} jaka jest godzina  sekund
-we {location} jaka jest godzina  sekund od teraz
-we {location} jaka jest godzina  sekundy
-we {location} jaka jest godzina  sekundy od teraz
+we {location} jaka jest godzina za {offset} godzin
+we {location} jaka jest godzina za {offset} godzin od teraz
+we {location} jaka jest godzina za {offset} godziny
+we {location} jaka jest godzina za {offset} godziny od teraz
+we {location} jaka jest godzina za {offset} minut
+we {location} jaka jest godzina za {offset} minut od teraz
+we {location} jaka jest godzina za {offset} minuty
+we {location} jaka jest godzina za {offset} minuty od teraz
+we {location} jaka jest godzina za {offset} sekund
+we {location} jaka jest godzina za {offset} sekund od teraz
+we {location} jaka jest godzina za {offset} sekundy
+we {location} jaka jest godzina za {offset} sekundy od teraz
 we {location} jaka jest godzina  {offset} godzin
 we {location} jaka jest godzina  {offset} godzin od teraz
 we {location} jaka jest godzina  {offset} godziny
@@ -4030,18 +3646,18 @@ we {location} jaka jest godzina za {offset} sekund
 we {location} jaka jest godzina za {offset} sekund od teraz
 we {location} jaka jest godzina za {offset} sekundy
 we {location} jaka jest godzina za {offset} sekundy od teraz
-we {location} jaki będzie czas  godzin
-we {location} jaki będzie czas  godzin od teraz
-we {location} jaki będzie czas  godziny
-we {location} jaki będzie czas  godziny od teraz
-we {location} jaki będzie czas  minut
-we {location} jaki będzie czas  minut od teraz
-we {location} jaki będzie czas  minuty
-we {location} jaki będzie czas  minuty od teraz
-we {location} jaki będzie czas  sekund
-we {location} jaki będzie czas  sekund od teraz
-we {location} jaki będzie czas  sekundy
-we {location} jaki będzie czas  sekundy od teraz
+we {location} jaki będzie czas za {offset} godzin
+we {location} jaki będzie czas za {offset} godzin od teraz
+we {location} jaki będzie czas za {offset} godziny
+we {location} jaki będzie czas za {offset} godziny od teraz
+we {location} jaki będzie czas za {offset} minut
+we {location} jaki będzie czas za {offset} minut od teraz
+we {location} jaki będzie czas za {offset} minuty
+we {location} jaki będzie czas za {offset} minuty od teraz
+we {location} jaki będzie czas za {offset} sekund
+we {location} jaki będzie czas za {offset} sekund od teraz
+we {location} jaki będzie czas za {offset} sekundy
+we {location} jaki będzie czas za {offset} sekundy od teraz
 we {location} jaki będzie czas  {offset} godzin
 we {location} jaki będzie czas  {offset} godzin od teraz
 we {location} jaki będzie czas  {offset} godziny
@@ -4066,18 +3682,18 @@ we {location} jaki będzie czas za {offset} sekund
 we {location} jaki będzie czas za {offset} sekund od teraz
 we {location} jaki będzie czas za {offset} sekundy
 we {location} jaki będzie czas za {offset} sekundy od teraz
-we {location} jaki będzie godzina  godzin
-we {location} jaki będzie godzina  godzin od teraz
-we {location} jaki będzie godzina  godziny
-we {location} jaki będzie godzina  godziny od teraz
-we {location} jaki będzie godzina  minut
-we {location} jaki będzie godzina  minut od teraz
-we {location} jaki będzie godzina  minuty
-we {location} jaki będzie godzina  minuty od teraz
-we {location} jaki będzie godzina  sekund
-we {location} jaki będzie godzina  sekund od teraz
-we {location} jaki będzie godzina  sekundy
-we {location} jaki będzie godzina  sekundy od teraz
+we {location} jaki będzie godzina za {offset} godzin
+we {location} jaki będzie godzina za {offset} godzin od teraz
+we {location} jaki będzie godzina za {offset} godziny
+we {location} jaki będzie godzina za {offset} godziny od teraz
+we {location} jaki będzie godzina za {offset} minut
+we {location} jaki będzie godzina za {offset} minut od teraz
+we {location} jaki będzie godzina za {offset} minuty
+we {location} jaki będzie godzina za {offset} minuty od teraz
+we {location} jaki będzie godzina za {offset} sekund
+we {location} jaki będzie godzina za {offset} sekund od teraz
+we {location} jaki będzie godzina za {offset} sekundy
+we {location} jaki będzie godzina za {offset} sekundy od teraz
 we {location} jaki będzie godzina  {offset} godzin
 we {location} jaki będzie godzina  {offset} godzin od teraz
 we {location} jaki będzie godzina  {offset} godziny
@@ -4102,18 +3718,18 @@ we {location} jaki będzie godzina za {offset} sekund
 we {location} jaki będzie godzina za {offset} sekund od teraz
 we {location} jaki będzie godzina za {offset} sekundy
 we {location} jaki będzie godzina za {offset} sekundy od teraz
-we {location} jaki jest czas  godzin
-we {location} jaki jest czas  godzin od teraz
-we {location} jaki jest czas  godziny
-we {location} jaki jest czas  godziny od teraz
-we {location} jaki jest czas  minut
-we {location} jaki jest czas  minut od teraz
-we {location} jaki jest czas  minuty
-we {location} jaki jest czas  minuty od teraz
-we {location} jaki jest czas  sekund
-we {location} jaki jest czas  sekund od teraz
-we {location} jaki jest czas  sekundy
-we {location} jaki jest czas  sekundy od teraz
+we {location} jaki jest czas za {offset} godzin
+we {location} jaki jest czas za {offset} godzin od teraz
+we {location} jaki jest czas za {offset} godziny
+we {location} jaki jest czas za {offset} godziny od teraz
+we {location} jaki jest czas za {offset} minut
+we {location} jaki jest czas za {offset} minut od teraz
+we {location} jaki jest czas za {offset} minuty
+we {location} jaki jest czas za {offset} minuty od teraz
+we {location} jaki jest czas za {offset} sekund
+we {location} jaki jest czas za {offset} sekund od teraz
+we {location} jaki jest czas za {offset} sekundy
+we {location} jaki jest czas za {offset} sekundy od teraz
 we {location} jaki jest czas  {offset} godzin
 we {location} jaki jest czas  {offset} godzin od teraz
 we {location} jaki jest czas  {offset} godziny
@@ -4138,18 +3754,18 @@ we {location} jaki jest czas za {offset} sekund
 we {location} jaki jest czas za {offset} sekund od teraz
 we {location} jaki jest czas za {offset} sekundy
 we {location} jaki jest czas za {offset} sekundy od teraz
-we {location} jaki jest godzina  godzin
-we {location} jaki jest godzina  godzin od teraz
-we {location} jaki jest godzina  godziny
-we {location} jaki jest godzina  godziny od teraz
-we {location} jaki jest godzina  minut
-we {location} jaki jest godzina  minut od teraz
-we {location} jaki jest godzina  minuty
-we {location} jaki jest godzina  minuty od teraz
-we {location} jaki jest godzina  sekund
-we {location} jaki jest godzina  sekund od teraz
-we {location} jaki jest godzina  sekundy
-we {location} jaki jest godzina  sekundy od teraz
+we {location} jaki jest godzina za {offset} godzin
+we {location} jaki jest godzina za {offset} godzin od teraz
+we {location} jaki jest godzina za {offset} godziny
+we {location} jaki jest godzina za {offset} godziny od teraz
+we {location} jaki jest godzina za {offset} minut
+we {location} jaki jest godzina za {offset} minut od teraz
+we {location} jaki jest godzina za {offset} minuty
+we {location} jaki jest godzina za {offset} minuty od teraz
+we {location} jaki jest godzina za {offset} sekund
+we {location} jaki jest godzina za {offset} sekund od teraz
+we {location} jaki jest godzina za {offset} sekundy
+we {location} jaki jest godzina za {offset} sekundy od teraz
 we {location} jaki jest godzina  {offset} godzin
 we {location} jaki jest godzina  {offset} godzin od teraz
 we {location} jaki jest godzina  {offset} godziny
@@ -4174,18 +3790,18 @@ we {location} jaki jest godzina za {offset} sekund
 we {location} jaki jest godzina za {offset} sekund od teraz
 we {location} jaki jest godzina za {offset} sekundy
 we {location} jaki jest godzina za {offset} sekundy od teraz
-we {location} która będzie czas  godzin
-we {location} która będzie czas  godzin od teraz
-we {location} która będzie czas  godziny
-we {location} która będzie czas  godziny od teraz
-we {location} która będzie czas  minut
-we {location} która będzie czas  minut od teraz
-we {location} która będzie czas  minuty
-we {location} która będzie czas  minuty od teraz
-we {location} która będzie czas  sekund
-we {location} która będzie czas  sekund od teraz
-we {location} która będzie czas  sekundy
-we {location} która będzie czas  sekundy od teraz
+we {location} która będzie czas za {offset} godzin
+we {location} która będzie czas za {offset} godzin od teraz
+we {location} która będzie czas za {offset} godziny
+we {location} która będzie czas za {offset} godziny od teraz
+we {location} która będzie czas za {offset} minut
+we {location} która będzie czas za {offset} minut od teraz
+we {location} która będzie czas za {offset} minuty
+we {location} która będzie czas za {offset} minuty od teraz
+we {location} która będzie czas za {offset} sekund
+we {location} która będzie czas za {offset} sekund od teraz
+we {location} która będzie czas za {offset} sekundy
+we {location} która będzie czas za {offset} sekundy od teraz
 we {location} która będzie czas  {offset} godzin
 we {location} która będzie czas  {offset} godzin od teraz
 we {location} która będzie czas  {offset} godziny
@@ -4210,18 +3826,18 @@ we {location} która będzie czas za {offset} sekund
 we {location} która będzie czas za {offset} sekund od teraz
 we {location} która będzie czas za {offset} sekundy
 we {location} która będzie czas za {offset} sekundy od teraz
-we {location} która będzie godzina  godzin
-we {location} która będzie godzina  godzin od teraz
-we {location} która będzie godzina  godziny
-we {location} która będzie godzina  godziny od teraz
-we {location} która będzie godzina  minut
-we {location} która będzie godzina  minut od teraz
-we {location} która będzie godzina  minuty
-we {location} która będzie godzina  minuty od teraz
-we {location} która będzie godzina  sekund
-we {location} która będzie godzina  sekund od teraz
-we {location} która będzie godzina  sekundy
-we {location} która będzie godzina  sekundy od teraz
+we {location} która będzie godzina za {offset} godzin
+we {location} która będzie godzina za {offset} godzin od teraz
+we {location} która będzie godzina za {offset} godziny
+we {location} która będzie godzina za {offset} godziny od teraz
+we {location} która będzie godzina za {offset} minut
+we {location} która będzie godzina za {offset} minut od teraz
+we {location} która będzie godzina za {offset} minuty
+we {location} która będzie godzina za {offset} minuty od teraz
+we {location} która będzie godzina za {offset} sekund
+we {location} która będzie godzina za {offset} sekund od teraz
+we {location} która będzie godzina za {offset} sekundy
+we {location} która będzie godzina za {offset} sekundy od teraz
 we {location} która będzie godzina  {offset} godzin
 we {location} która będzie godzina  {offset} godzin od teraz
 we {location} która będzie godzina  {offset} godziny
@@ -4246,18 +3862,18 @@ we {location} która będzie godzina za {offset} sekund
 we {location} która będzie godzina za {offset} sekund od teraz
 we {location} która będzie godzina za {offset} sekundy
 we {location} która będzie godzina za {offset} sekundy od teraz
-we {location} która jest czas  godzin
-we {location} która jest czas  godzin od teraz
-we {location} która jest czas  godziny
-we {location} która jest czas  godziny od teraz
-we {location} która jest czas  minut
-we {location} która jest czas  minut od teraz
-we {location} która jest czas  minuty
-we {location} która jest czas  minuty od teraz
-we {location} która jest czas  sekund
-we {location} która jest czas  sekund od teraz
-we {location} która jest czas  sekundy
-we {location} która jest czas  sekundy od teraz
+we {location} która jest czas za {offset} godzin
+we {location} która jest czas za {offset} godzin od teraz
+we {location} która jest czas za {offset} godziny
+we {location} która jest czas za {offset} godziny od teraz
+we {location} która jest czas za {offset} minut
+we {location} która jest czas za {offset} minut od teraz
+we {location} która jest czas za {offset} minuty
+we {location} która jest czas za {offset} minuty od teraz
+we {location} która jest czas za {offset} sekund
+we {location} która jest czas za {offset} sekund od teraz
+we {location} która jest czas za {offset} sekundy
+we {location} która jest czas za {offset} sekundy od teraz
 we {location} która jest czas  {offset} godzin
 we {location} która jest czas  {offset} godzin od teraz
 we {location} która jest czas  {offset} godziny
@@ -4282,18 +3898,18 @@ we {location} która jest czas za {offset} sekund
 we {location} która jest czas za {offset} sekund od teraz
 we {location} która jest czas za {offset} sekundy
 we {location} która jest czas za {offset} sekundy od teraz
-we {location} która jest godzina  godzin
-we {location} która jest godzina  godzin od teraz
-we {location} która jest godzina  godziny
-we {location} która jest godzina  godziny od teraz
-we {location} która jest godzina  minut
-we {location} która jest godzina  minut od teraz
-we {location} która jest godzina  minuty
-we {location} która jest godzina  minuty od teraz
-we {location} która jest godzina  sekund
-we {location} która jest godzina  sekund od teraz
-we {location} która jest godzina  sekundy
-we {location} która jest godzina  sekundy od teraz
+we {location} która jest godzina za {offset} godzin
+we {location} która jest godzina za {offset} godzin od teraz
+we {location} która jest godzina za {offset} godziny
+we {location} która jest godzina za {offset} godziny od teraz
+we {location} która jest godzina za {offset} minut
+we {location} która jest godzina za {offset} minut od teraz
+we {location} która jest godzina za {offset} minuty
+we {location} która jest godzina za {offset} minuty od teraz
+we {location} która jest godzina za {offset} sekund
+we {location} która jest godzina za {offset} sekund od teraz
+we {location} która jest godzina za {offset} sekundy
+we {location} która jest godzina za {offset} sekundy od teraz
 we {location} która jest godzina  {offset} godzin
 we {location} która jest godzina  {offset} godzin od teraz
 we {location} która jest godzina  {offset} godziny

--- a/locale/pt-BR/intents/time.until.intent
+++ b/locale/pt-BR/intents/time.until.intent
@@ -18,16 +18,16 @@ quantas horas restam antes {date}
 quantas horas restam até {date}
 quantas semanas restam antes {date}
 quantas semanas restam até {date}
-quanto tempo ainda falta antes {data}
-quanto tempo ainda falta até {data}
+quanto tempo ainda falta antes {date}
+quanto tempo ainda falta até {date}
 quanto tempo resta antes de {date}
-quanto tempo temos antes {data}
-quanto tempo temos até {data}
+quanto tempo temos antes {date}
+quanto tempo temos até {date}
 quanto tempo vai demorar para {date}
 quantos dias a partir de agora é {date}
-quão longe distante está {data}
-quão longe distante está {data} de agora
-quão longe distante está {data} de hoje
-quão longe fora está {data}
-quão longe fora está {data} de agora
-quão longe fora está {data} de hoje
+quão longe distante está {date}
+quão longe distante está {date} de agora
+quão longe distante está {date} de hoje
+quão longe fora está {date}
+quão longe fora está {date} de agora
+quão longe fora está {date} de hoje

--- a/locale/pt-BR/intents/weekday.for.date.intent
+++ b/locale/pt-BR/intents/weekday.for.date.intent
@@ -6,24 +6,24 @@ Eu gostaria de saber que dia da semana era {date}
 Eu gostaria de saber que dia da semana é {date}
 Eu gostaria de saber que dia era {date}
 Eu gostaria de saber que dia é {date}
-em qual dia da semana era {data}
+em qual dia da semana era {date}
 em qual dia da semana foi o {date}
 em qual dia da semana será o {date}
 em qual dia da semana {date} cai
-em qual dia da semana é {data}
-em qual dia era {data}
+em qual dia da semana é {date}
+em qual dia era {date}
 em qual dia foi o {date}
 em qual dia será o {date}
 em qual dia {date} cai
-em qual dia é {data}
-em que dia da semana era {data}
+em qual dia é {date}
+em que dia da semana era {date}
 em que dia da semana foi o {date}
 em que dia da semana será o {date}
-em que dia da semana é {data}
-em que dia era {data}
+em que dia da semana é {date}
+em que dia era {date}
 em que dia foi o {date}
 em que dia será o {date}
-em que dia é {data}
+em que dia é {date}
 era {date}  uma domingo
 era {date}  uma quarta-feira
 era {date}  uma quinta-feira
@@ -43,32 +43,32 @@ pode me dizer qual dia da semana era o {date}
 pode me dizer qual dia da semana é o {date}
 pode me dizer qual dia era o {date}
 pode me dizer qual dia é o {date}
-qual dia da semana era {data}
+qual dia da semana era {date}
 qual dia da semana era {date}
 qual dia da semana foi o {date}
 qual dia da semana será o {date}
 qual dia da semana {date} cai
-qual dia da semana é {data}
 qual dia da semana é {date}
-qual dia era {data}
+qual dia da semana é {date}
+qual dia era {date}
 qual dia era {date}
 qual dia foi o {date}
 qual dia será o {date}
 qual dia {date} cai
-qual dia é {data}
+qual dia é {date}
 qual dia é {date}
 qual é o dia da semana para {date}
-que dia da semana era {data}
+que dia da semana era {date}
 que dia da semana era {date}
 que dia da semana foi o {date}
 que dia da semana será o {date}
-que dia da semana é {data}
 que dia da semana é {date}
-que dia era {data}
+que dia da semana é {date}
+que dia era {date}
 que dia era {date}
 que dia foi o {date}
 que dia será o {date}
-que dia é {data}
+que dia é {date}
 que dia é {date}
 você sabe o dia da semana para {date}
 você sabe qual dia da semana era {date}

--- a/locale/pt-PT/intents/current_date.intent
+++ b/locale/pt-PT/intents/current_date.intent
@@ -69,13 +69,13 @@ qual a data atual
 qual a data atual em {location}
 qual a data completa
 qual a data completa atual
-qual a data completa atual em {local}
+qual a data completa atual em {location}
 qual a data completa de hoje incluindo o ano
 qual a data completa em {location}
 qual a data completa hoje
-qual a data completa hoje em {local}
+qual a data completa hoje em {location}
 qual a data completa presente
-qual a data completa presente em {local}
+qual a data completa presente em {location}
 qual a data presente
 qual a data presente em {location}
 qual é a data de hoje

--- a/locale/pt-PT/intents/time.until.intent
+++ b/locale/pt-PT/intents/time.until.intent
@@ -1,33 +1,33 @@
-há quanto tempo foi {data}
-há quantos dias foi {data}
-quando  será {data}
-quando  é {data}
-quando exatamente será {data}
-quando exatamente é {data}
-quando foi a anterior {data}
-quando foi a próxima {data}
-quando foi a última {data}
-quando foi {data}
-quando é a anterior {data}
-quando é a próxima {data}
-quando é a última {data}
-quando é {data}
-quantas dias restam antes {data}
-quantas dias restam até {data}
-quantas horas restam antes {data}
-quantas horas restam até {data}
-quantas semanas restam antes {data}
-quantas semanas restam até {data}
-quanto tempo ainda falta antes {data}
-quanto tempo ainda falta até {data}
-quanto tempo falta antes de {data}
-quanto tempo temos antes {data}
-quanto tempo temos até {data}
-quanto tempo vai demorar para {data}
-quantos dias a partir de agora é {data}
-quão longe distante está {data}
-quão longe distante está {data} de agora
-quão longe distante está {data} de hoje
-quão longe fora está {data}
-quão longe fora está {data} de agora
-quão longe fora está {data} de hoje
+há quanto tempo foi {date}
+há quantos dias foi {date}
+quando  será {date}
+quando  é {date}
+quando exatamente será {date}
+quando exatamente é {date}
+quando foi a anterior {date}
+quando foi a próxima {date}
+quando foi a última {date}
+quando foi {date}
+quando é a anterior {date}
+quando é a próxima {date}
+quando é a última {date}
+quando é {date}
+quantas dias restam antes {date}
+quantas dias restam até {date}
+quantas horas restam antes {date}
+quantas horas restam até {date}
+quantas semanas restam antes {date}
+quantas semanas restam até {date}
+quanto tempo ainda falta antes {date}
+quanto tempo ainda falta até {date}
+quanto tempo falta antes de {date}
+quanto tempo temos antes {date}
+quanto tempo temos até {date}
+quanto tempo vai demorar para {date}
+quantos dias a partir de agora é {date}
+quão longe distante está {date}
+quão longe distante está {date} de agora
+quão longe distante está {date} de hoje
+quão longe fora está {date}
+quão longe fora está {date} de agora
+quão longe fora está {date} de hoje

--- a/locale/pt-PT/intents/what.time.will.it.be.intent
+++ b/locale/pt-PT/intents/what.time.will.it.be.intent
@@ -1,408 +1,408 @@
-em {deslocamento} hora  que horas serão
-em {deslocamento} hora  que horas serão em {location}
-em {deslocamento} hora a partir de agora que horas serão
-em {deslocamento} hora a partir de agora que horas serão em {location}
-em {deslocamento} horas  que horas serão
-em {deslocamento} horas  que horas serão em {location}
-em {deslocamento} horas a partir de agora que horas serão
-em {deslocamento} horas a partir de agora que horas serão em {location}
-em {deslocamento} minuto  que horas serão
-em {deslocamento} minuto  que horas serão em {location}
-em {deslocamento} minuto a partir de agora que horas serão
-em {deslocamento} minuto a partir de agora que horas serão em {location}
-em {deslocamento} minutos  que horas serão
-em {deslocamento} minutos  que horas serão em {location}
-em {deslocamento} minutos a partir de agora que horas serão
-em {deslocamento} minutos a partir de agora que horas serão em {location}
-em {deslocamento} segundo  que horas serão
-em {deslocamento} segundo  que horas serão em {location}
-em {deslocamento} segundo a partir de agora que horas serão
-em {deslocamento} segundo a partir de agora que horas serão em {location}
-em {deslocamento} segundos  que horas serão
-em {deslocamento} segundos  que horas serão em {location}
-em {deslocamento} segundos a partir de agora que horas serão
-em {deslocamento} segundos a partir de agora que horas serão em {location}
-o que o relógio dirá  depois {deslocamento} hora
-o que o relógio dirá  depois {deslocamento} hora em {location}
-o que o relógio dirá  depois {deslocamento} horas
-o que o relógio dirá  depois {deslocamento} horas em {location}
-o que o relógio dirá  depois {deslocamento} minuto
-o que o relógio dirá  depois {deslocamento} minuto em {location}
-o que o relógio dirá  depois {deslocamento} minutos
-o que o relógio dirá  depois {deslocamento} minutos em {location}
-o que o relógio dirá  depois {deslocamento} segundo
-o que o relógio dirá  depois {deslocamento} segundo em {location}
-o que o relógio dirá  depois {deslocamento} segundos
-o que o relógio dirá  depois {deslocamento} segundos em {location}
-o que o relógio dirá  se eu esperar  {deslocamento} hora
-o que o relógio dirá  se eu esperar  {deslocamento} hora em {location}
-o que o relógio dirá  se eu esperar  {deslocamento} horas
-o que o relógio dirá  se eu esperar  {deslocamento} horas em {location}
-o que o relógio dirá  se eu esperar  {deslocamento} minuto
-o que o relógio dirá  se eu esperar  {deslocamento} minuto em {location}
-o que o relógio dirá  se eu esperar  {deslocamento} minutos
-o que o relógio dirá  se eu esperar  {deslocamento} minutos em {location}
-o que o relógio dirá  se eu esperar  {deslocamento} segundo
-o que o relógio dirá  se eu esperar  {deslocamento} segundo em {location}
-o que o relógio dirá  se eu esperar  {deslocamento} segundos
-o que o relógio dirá  se eu esperar  {deslocamento} segundos em {location}
-o que o relógio dirá em  {deslocamento} hora
-o que o relógio dirá em  {deslocamento} hora em {location}
-o que o relógio dirá em  {deslocamento} horas
-o que o relógio dirá em  {deslocamento} horas em {location}
-o que o relógio dirá em  {deslocamento} minuto
-o que o relógio dirá em  {deslocamento} minuto em {location}
-o que o relógio dirá em  {deslocamento} minutos
-o que o relógio dirá em  {deslocamento} minutos em {location}
-o que o relógio dirá em  {deslocamento} segundo
-o que o relógio dirá em  {deslocamento} segundo em {location}
-o que o relógio dirá em  {deslocamento} segundos
-o que o relógio dirá em  {deslocamento} segundos em {location}
-quando horas isso mostrar depois de {deslocamento} hora
-quando horas isso mostrar depois de {deslocamento} hora em {location}
-quando horas isso mostrar depois de {deslocamento} horas
-quando horas isso mostrar depois de {deslocamento} horas em {location}
-quando horas isso mostrar depois de {deslocamento} minuto
-quando horas isso mostrar depois de {deslocamento} minuto em {location}
-quando horas isso mostrar depois de {deslocamento} minutos
-quando horas isso mostrar depois de {deslocamento} minutos em {location}
-quando horas isso mostrar depois de {deslocamento} segundo
-quando horas isso mostrar depois de {deslocamento} segundo em {location}
-quando horas isso mostrar depois de {deslocamento} segundos
-quando horas isso mostrar depois de {deslocamento} segundos em {location}
-quando horas isso mostrar em {deslocamento} hora
-quando horas isso mostrar em {deslocamento} hora em {location}
-quando horas isso mostrar em {deslocamento} horas
-quando horas isso mostrar em {deslocamento} horas em {location}
-quando horas isso mostrar em {deslocamento} minuto
-quando horas isso mostrar em {deslocamento} minuto em {location}
-quando horas isso mostrar em {deslocamento} minutos
-quando horas isso mostrar em {deslocamento} minutos em {location}
-quando horas isso mostrar em {deslocamento} segundo
-quando horas isso mostrar em {deslocamento} segundo em {location}
-quando horas isso mostrar em {deslocamento} segundos
-quando horas isso mostrar em {deslocamento} segundos em {location}
-quando horas isso mostrar se eu esperar {deslocamento} hora
-quando horas isso mostrar se eu esperar {deslocamento} hora em {location}
-quando horas isso mostrar se eu esperar {deslocamento} horas
-quando horas isso mostrar se eu esperar {deslocamento} horas em {location}
-quando horas isso mostrar se eu esperar {deslocamento} minuto
-quando horas isso mostrar se eu esperar {deslocamento} minuto em {location}
-quando horas isso mostrar se eu esperar {deslocamento} minutos
-quando horas isso mostrar se eu esperar {deslocamento} minutos em {location}
-quando horas isso mostrar se eu esperar {deslocamento} segundo
-quando horas isso mostrar se eu esperar {deslocamento} segundo em {location}
-quando horas isso mostrar se eu esperar {deslocamento} segundos
-quando horas isso mostrar se eu esperar {deslocamento} segundos em {location}
-quando horas isso será depois de {deslocamento} hora
-quando horas isso será depois de {deslocamento} hora em {location}
-quando horas isso será depois de {deslocamento} horas
-quando horas isso será depois de {deslocamento} horas em {location}
-quando horas isso será depois de {deslocamento} minuto
-quando horas isso será depois de {deslocamento} minuto em {location}
-quando horas isso será depois de {deslocamento} minutos
-quando horas isso será depois de {deslocamento} minutos em {location}
-quando horas isso será depois de {deslocamento} segundo
-quando horas isso será depois de {deslocamento} segundo em {location}
-quando horas isso será depois de {deslocamento} segundos
-quando horas isso será depois de {deslocamento} segundos em {location}
-quando horas isso será em {deslocamento} hora
-quando horas isso será em {deslocamento} hora em {location}
-quando horas isso será em {deslocamento} horas
-quando horas isso será em {deslocamento} horas em {location}
-quando horas isso será em {deslocamento} minuto
-quando horas isso será em {deslocamento} minuto em {location}
-quando horas isso será em {deslocamento} minutos
-quando horas isso será em {deslocamento} minutos em {location}
-quando horas isso será em {deslocamento} segundo
-quando horas isso será em {deslocamento} segundo em {location}
-quando horas isso será em {deslocamento} segundos
-quando horas isso será em {deslocamento} segundos em {location}
-quando horas isso será se eu esperar {deslocamento} hora
-quando horas isso será se eu esperar {deslocamento} hora em {location}
-quando horas isso será se eu esperar {deslocamento} horas
-quando horas isso será se eu esperar {deslocamento} horas em {location}
-quando horas isso será se eu esperar {deslocamento} minuto
-quando horas isso será se eu esperar {deslocamento} minuto em {location}
-quando horas isso será se eu esperar {deslocamento} minutos
-quando horas isso será se eu esperar {deslocamento} minutos em {location}
-quando horas isso será se eu esperar {deslocamento} segundo
-quando horas isso será se eu esperar {deslocamento} segundo em {location}
-quando horas isso será se eu esperar {deslocamento} segundos
-quando horas isso será se eu esperar {deslocamento} segundos em {location}
-quando horas isso tornar-se-á depois de {deslocamento} hora
-quando horas isso tornar-se-á depois de {deslocamento} hora em {location}
-quando horas isso tornar-se-á depois de {deslocamento} horas
-quando horas isso tornar-se-á depois de {deslocamento} horas em {location}
-quando horas isso tornar-se-á depois de {deslocamento} minuto
-quando horas isso tornar-se-á depois de {deslocamento} minuto em {location}
-quando horas isso tornar-se-á depois de {deslocamento} minutos
-quando horas isso tornar-se-á depois de {deslocamento} minutos em {location}
-quando horas isso tornar-se-á depois de {deslocamento} segundo
-quando horas isso tornar-se-á depois de {deslocamento} segundo em {location}
-quando horas isso tornar-se-á depois de {deslocamento} segundos
-quando horas isso tornar-se-á depois de {deslocamento} segundos em {location}
-quando horas isso tornar-se-á em {deslocamento} hora
-quando horas isso tornar-se-á em {deslocamento} hora em {location}
-quando horas isso tornar-se-á em {deslocamento} horas
-quando horas isso tornar-se-á em {deslocamento} horas em {location}
-quando horas isso tornar-se-á em {deslocamento} minuto
-quando horas isso tornar-se-á em {deslocamento} minuto em {location}
-quando horas isso tornar-se-á em {deslocamento} minutos
-quando horas isso tornar-se-á em {deslocamento} minutos em {location}
-quando horas isso tornar-se-á em {deslocamento} segundo
-quando horas isso tornar-se-á em {deslocamento} segundo em {location}
-quando horas isso tornar-se-á em {deslocamento} segundos
-quando horas isso tornar-se-á em {deslocamento} segundos em {location}
-quando horas isso tornar-se-á se eu esperar {deslocamento} hora
-quando horas isso tornar-se-á se eu esperar {deslocamento} hora em {location}
-quando horas isso tornar-se-á se eu esperar {deslocamento} horas
-quando horas isso tornar-se-á se eu esperar {deslocamento} horas em {location}
-quando horas isso tornar-se-á se eu esperar {deslocamento} minuto
-quando horas isso tornar-se-á se eu esperar {deslocamento} minuto em {location}
-quando horas isso tornar-se-á se eu esperar {deslocamento} minutos
-quando horas isso tornar-se-á se eu esperar {deslocamento} minutos em {location}
-quando horas isso tornar-se-á se eu esperar {deslocamento} segundo
-quando horas isso tornar-se-á se eu esperar {deslocamento} segundo em {location}
-quando horas isso tornar-se-á se eu esperar {deslocamento} segundos
-quando horas isso tornar-se-á se eu esperar {deslocamento} segundos em {location}
-quando será {deslocamento} horas
-quando será {deslocamento} horas  em {location}
-quando será {deslocamento} horas a partir de agora
-quando será {deslocamento} horas a partir de agora em {location}
-quando será {deslocamento} minutos
-quando será {deslocamento} minutos  em {location}
-quando será {deslocamento} minutos a partir de agora
-quando será {deslocamento} minutos a partir de agora em {location}
-quando será {deslocamento} segundos
-quando será {deslocamento} segundos  em {location}
-quando será {deslocamento} segundos a partir de agora
-quando será {deslocamento} segundos a partir de agora em {location}
-quando serão se eu esperar {deslocamento} hora
-quando serão se eu esperar {deslocamento} hora em {location}
-quando serão se eu esperar {deslocamento} horas
-quando serão se eu esperar {deslocamento} horas em {location}
-quando serão se eu esperar {deslocamento} minuto
-quando serão se eu esperar {deslocamento} minuto em {location}
-quando serão se eu esperar {deslocamento} minutos
-quando serão se eu esperar {deslocamento} minutos em {location}
-quando serão se eu esperar {deslocamento} segundo
-quando serão se eu esperar {deslocamento} segundo em {location}
-quando serão se eu esperar {deslocamento} segundos
-quando serão se eu esperar {deslocamento} segundos em {location}
-quando serão se eu gastar {deslocamento} hora
-quando serão se eu gastar {deslocamento} hora em {location}
-quando serão se eu gastar {deslocamento} horas
-quando serão se eu gastar {deslocamento} horas em {location}
-quando serão se eu gastar {deslocamento} minuto
-quando serão se eu gastar {deslocamento} minuto em {location}
-quando serão se eu gastar {deslocamento} minutos
-quando serão se eu gastar {deslocamento} minutos em {location}
-quando serão se eu gastar {deslocamento} segundo
-quando serão se eu gastar {deslocamento} segundo em {location}
-quando serão se eu gastar {deslocamento} segundos
-quando serão se eu gastar {deslocamento} segundos em {location}
-quando é {deslocamento} horas
-quando é {deslocamento} horas  em {location}
-quando é {deslocamento} horas a partir de agora
-quando é {deslocamento} horas a partir de agora em {location}
-quando é {deslocamento} minutos
-quando é {deslocamento} minutos  em {location}
-quando é {deslocamento} minutos a partir de agora
-quando é {deslocamento} minutos a partir de agora em {location}
-quando é {deslocamento} segundos
-quando é {deslocamento} segundos  em {location}
-quando é {deslocamento} segundos a partir de agora
-quando é {deslocamento} segundos a partir de agora em {location}
-que horas isso mostrar depois de {deslocamento} hora
-que horas isso mostrar depois de {deslocamento} hora em {location}
-que horas isso mostrar depois de {deslocamento} horas
-que horas isso mostrar depois de {deslocamento} horas em {location}
-que horas isso mostrar depois de {deslocamento} minuto
-que horas isso mostrar depois de {deslocamento} minuto em {location}
-que horas isso mostrar depois de {deslocamento} minutos
-que horas isso mostrar depois de {deslocamento} minutos em {location}
-que horas isso mostrar depois de {deslocamento} segundo
-que horas isso mostrar depois de {deslocamento} segundo em {location}
-que horas isso mostrar depois de {deslocamento} segundos
-que horas isso mostrar depois de {deslocamento} segundos em {location}
-que horas isso mostrar em {deslocamento} hora
-que horas isso mostrar em {deslocamento} hora em {location}
-que horas isso mostrar em {deslocamento} horas
-que horas isso mostrar em {deslocamento} horas em {location}
-que horas isso mostrar em {deslocamento} minuto
-que horas isso mostrar em {deslocamento} minuto em {location}
-que horas isso mostrar em {deslocamento} minutos
-que horas isso mostrar em {deslocamento} minutos em {location}
-que horas isso mostrar em {deslocamento} segundo
-que horas isso mostrar em {deslocamento} segundo em {location}
-que horas isso mostrar em {deslocamento} segundos
-que horas isso mostrar em {deslocamento} segundos em {location}
-que horas isso mostrar se eu esperar {deslocamento} hora
-que horas isso mostrar se eu esperar {deslocamento} hora em {location}
-que horas isso mostrar se eu esperar {deslocamento} horas
-que horas isso mostrar se eu esperar {deslocamento} horas em {location}
-que horas isso mostrar se eu esperar {deslocamento} minuto
-que horas isso mostrar se eu esperar {deslocamento} minuto em {location}
-que horas isso mostrar se eu esperar {deslocamento} minutos
-que horas isso mostrar se eu esperar {deslocamento} minutos em {location}
-que horas isso mostrar se eu esperar {deslocamento} segundo
-que horas isso mostrar se eu esperar {deslocamento} segundo em {location}
-que horas isso mostrar se eu esperar {deslocamento} segundos
-que horas isso mostrar se eu esperar {deslocamento} segundos em {location}
-que horas isso será depois de {deslocamento} hora
-que horas isso será depois de {deslocamento} hora em {location}
-que horas isso será depois de {deslocamento} horas
-que horas isso será depois de {deslocamento} horas em {location}
-que horas isso será depois de {deslocamento} minuto
-que horas isso será depois de {deslocamento} minuto em {location}
-que horas isso será depois de {deslocamento} minutos
-que horas isso será depois de {deslocamento} minutos em {location}
-que horas isso será depois de {deslocamento} segundo
-que horas isso será depois de {deslocamento} segundo em {location}
-que horas isso será depois de {deslocamento} segundos
-que horas isso será depois de {deslocamento} segundos em {location}
-que horas isso será em {deslocamento} hora
-que horas isso será em {deslocamento} hora em {location}
-que horas isso será em {deslocamento} horas
-que horas isso será em {deslocamento} horas em {location}
-que horas isso será em {deslocamento} minuto
-que horas isso será em {deslocamento} minuto em {location}
-que horas isso será em {deslocamento} minutos
-que horas isso será em {deslocamento} minutos em {location}
-que horas isso será em {deslocamento} segundo
-que horas isso será em {deslocamento} segundo em {location}
-que horas isso será em {deslocamento} segundos
-que horas isso será em {deslocamento} segundos em {location}
-que horas isso será se eu esperar {deslocamento} hora
-que horas isso será se eu esperar {deslocamento} hora em {location}
-que horas isso será se eu esperar {deslocamento} horas
-que horas isso será se eu esperar {deslocamento} horas em {location}
-que horas isso será se eu esperar {deslocamento} minuto
-que horas isso será se eu esperar {deslocamento} minuto em {location}
-que horas isso será se eu esperar {deslocamento} minutos
-que horas isso será se eu esperar {deslocamento} minutos em {location}
-que horas isso será se eu esperar {deslocamento} segundo
-que horas isso será se eu esperar {deslocamento} segundo em {location}
-que horas isso será se eu esperar {deslocamento} segundos
-que horas isso será se eu esperar {deslocamento} segundos em {location}
-que horas isso tornar-se-á depois de {deslocamento} hora
-que horas isso tornar-se-á depois de {deslocamento} hora em {location}
-que horas isso tornar-se-á depois de {deslocamento} horas
-que horas isso tornar-se-á depois de {deslocamento} horas em {location}
-que horas isso tornar-se-á depois de {deslocamento} minuto
-que horas isso tornar-se-á depois de {deslocamento} minuto em {location}
-que horas isso tornar-se-á depois de {deslocamento} minutos
-que horas isso tornar-se-á depois de {deslocamento} minutos em {location}
-que horas isso tornar-se-á depois de {deslocamento} segundo
-que horas isso tornar-se-á depois de {deslocamento} segundo em {location}
-que horas isso tornar-se-á depois de {deslocamento} segundos
-que horas isso tornar-se-á depois de {deslocamento} segundos em {location}
-que horas isso tornar-se-á em {deslocamento} hora
-que horas isso tornar-se-á em {deslocamento} hora em {location}
-que horas isso tornar-se-á em {deslocamento} horas
-que horas isso tornar-se-á em {deslocamento} horas em {location}
-que horas isso tornar-se-á em {deslocamento} minuto
-que horas isso tornar-se-á em {deslocamento} minuto em {location}
-que horas isso tornar-se-á em {deslocamento} minutos
-que horas isso tornar-se-á em {deslocamento} minutos em {location}
-que horas isso tornar-se-á em {deslocamento} segundo
-que horas isso tornar-se-á em {deslocamento} segundo em {location}
-que horas isso tornar-se-á em {deslocamento} segundos
-que horas isso tornar-se-á em {deslocamento} segundos em {location}
-que horas isso tornar-se-á se eu esperar {deslocamento} hora
-que horas isso tornar-se-á se eu esperar {deslocamento} hora em {location}
-que horas isso tornar-se-á se eu esperar {deslocamento} horas
-que horas isso tornar-se-á se eu esperar {deslocamento} horas em {location}
-que horas isso tornar-se-á se eu esperar {deslocamento} minuto
-que horas isso tornar-se-á se eu esperar {deslocamento} minuto em {location}
-que horas isso tornar-se-á se eu esperar {deslocamento} minutos
-que horas isso tornar-se-á se eu esperar {deslocamento} minutos em {location}
-que horas isso tornar-se-á se eu esperar {deslocamento} segundo
-que horas isso tornar-se-á se eu esperar {deslocamento} segundo em {location}
-que horas isso tornar-se-á se eu esperar {deslocamento} segundos
-que horas isso tornar-se-á se eu esperar {deslocamento} segundos em {location}
-que horas será {deslocamento} horas
-que horas será {deslocamento} horas  em {location}
-que horas será {deslocamento} horas a partir de agora
-que horas será {deslocamento} horas a partir de agora em {location}
-que horas será {deslocamento} minutos
-que horas será {deslocamento} minutos  em {location}
-que horas será {deslocamento} minutos a partir de agora
-que horas será {deslocamento} minutos a partir de agora em {location}
-que horas será {deslocamento} segundos
-que horas será {deslocamento} segundos  em {location}
-que horas será {deslocamento} segundos a partir de agora
-que horas será {deslocamento} segundos a partir de agora em {location}
-que horas serão se eu esperar {deslocamento} hora
-que horas serão se eu esperar {deslocamento} hora em {location}
-que horas serão se eu esperar {deslocamento} horas
-que horas serão se eu esperar {deslocamento} horas em {location}
-que horas serão se eu esperar {deslocamento} minuto
-que horas serão se eu esperar {deslocamento} minuto em {location}
-que horas serão se eu esperar {deslocamento} minutos
-que horas serão se eu esperar {deslocamento} minutos em {location}
-que horas serão se eu esperar {deslocamento} segundo
-que horas serão se eu esperar {deslocamento} segundo em {location}
-que horas serão se eu esperar {deslocamento} segundos
-que horas serão se eu esperar {deslocamento} segundos em {location}
-que horas serão se eu gastar {deslocamento} hora
-que horas serão se eu gastar {deslocamento} hora em {location}
-que horas serão se eu gastar {deslocamento} horas
-que horas serão se eu gastar {deslocamento} horas em {location}
-que horas serão se eu gastar {deslocamento} minuto
-que horas serão se eu gastar {deslocamento} minuto em {location}
-que horas serão se eu gastar {deslocamento} minutos
-que horas serão se eu gastar {deslocamento} minutos em {location}
-que horas serão se eu gastar {deslocamento} segundo
-que horas serão se eu gastar {deslocamento} segundo em {location}
-que horas serão se eu gastar {deslocamento} segundos
-que horas serão se eu gastar {deslocamento} segundos em {location}
-que horas são   depois {deslocamento} hora
-que horas são   depois {deslocamento} hora em {location}
-que horas são   depois {deslocamento} horas
-que horas são   depois {deslocamento} horas em {location}
-que horas são   depois {deslocamento} minuto
-que horas são   depois {deslocamento} minuto em {location}
-que horas são   depois {deslocamento} minutos
-que horas são   depois {deslocamento} minutos em {location}
-que horas são   depois {deslocamento} segundo
-que horas são   depois {deslocamento} segundo em {location}
-que horas são   depois {deslocamento} segundos
-que horas são   depois {deslocamento} segundos em {location}
-que horas são   se eu esperar  {deslocamento} hora
-que horas são   se eu esperar  {deslocamento} hora em {location}
-que horas são   se eu esperar  {deslocamento} horas
-que horas são   se eu esperar  {deslocamento} horas em {location}
-que horas são   se eu esperar  {deslocamento} minuto
-que horas são   se eu esperar  {deslocamento} minuto em {location}
-que horas são   se eu esperar  {deslocamento} minutos
-que horas são   se eu esperar  {deslocamento} minutos em {location}
-que horas são   se eu esperar  {deslocamento} segundo
-que horas são   se eu esperar  {deslocamento} segundo em {location}
-que horas são   se eu esperar  {deslocamento} segundos
-que horas são   se eu esperar  {deslocamento} segundos em {location}
-que horas são  em  {deslocamento} hora
-que horas são  em  {deslocamento} hora em {location}
-que horas são  em  {deslocamento} horas
-que horas são  em  {deslocamento} horas em {location}
-que horas são  em  {deslocamento} minuto
-que horas são  em  {deslocamento} minuto em {location}
-que horas são  em  {deslocamento} minutos
-que horas são  em  {deslocamento} minutos em {location}
-que horas são  em  {deslocamento} segundo
-que horas são  em  {deslocamento} segundo em {location}
-que horas são  em  {deslocamento} segundos
-que horas são  em  {deslocamento} segundos em {location}
-que horas é {deslocamento} horas
-que horas é {deslocamento} horas  em {location}
-que horas é {deslocamento} horas a partir de agora
-que horas é {deslocamento} horas a partir de agora em {location}
-que horas é {deslocamento} minutos
-que horas é {deslocamento} minutos  em {location}
-que horas é {deslocamento} minutos a partir de agora
-que horas é {deslocamento} minutos a partir de agora em {location}
-que horas é {deslocamento} segundos
-que horas é {deslocamento} segundos  em {location}
-que horas é {deslocamento} segundos a partir de agora
-que horas é {deslocamento} segundos a partir de agora em {location}
+em {offset} hora  que horas serão
+em {offset} hora  que horas serão em {location}
+em {offset} hora a partir de agora que horas serão
+em {offset} hora a partir de agora que horas serão em {location}
+em {offset} horas  que horas serão
+em {offset} horas  que horas serão em {location}
+em {offset} horas a partir de agora que horas serão
+em {offset} horas a partir de agora que horas serão em {location}
+em {offset} minuto  que horas serão
+em {offset} minuto  que horas serão em {location}
+em {offset} minuto a partir de agora que horas serão
+em {offset} minuto a partir de agora que horas serão em {location}
+em {offset} minutos  que horas serão
+em {offset} minutos  que horas serão em {location}
+em {offset} minutos a partir de agora que horas serão
+em {offset} minutos a partir de agora que horas serão em {location}
+em {offset} segundo  que horas serão
+em {offset} segundo  que horas serão em {location}
+em {offset} segundo a partir de agora que horas serão
+em {offset} segundo a partir de agora que horas serão em {location}
+em {offset} segundos  que horas serão
+em {offset} segundos  que horas serão em {location}
+em {offset} segundos a partir de agora que horas serão
+em {offset} segundos a partir de agora que horas serão em {location}
+o que o relógio dirá  depois {offset} hora
+o que o relógio dirá  depois {offset} hora em {location}
+o que o relógio dirá  depois {offset} horas
+o que o relógio dirá  depois {offset} horas em {location}
+o que o relógio dirá  depois {offset} minuto
+o que o relógio dirá  depois {offset} minuto em {location}
+o que o relógio dirá  depois {offset} minutos
+o que o relógio dirá  depois {offset} minutos em {location}
+o que o relógio dirá  depois {offset} segundo
+o que o relógio dirá  depois {offset} segundo em {location}
+o que o relógio dirá  depois {offset} segundos
+o que o relógio dirá  depois {offset} segundos em {location}
+o que o relógio dirá  se eu esperar  {offset} hora
+o que o relógio dirá  se eu esperar  {offset} hora em {location}
+o que o relógio dirá  se eu esperar  {offset} horas
+o que o relógio dirá  se eu esperar  {offset} horas em {location}
+o que o relógio dirá  se eu esperar  {offset} minuto
+o que o relógio dirá  se eu esperar  {offset} minuto em {location}
+o que o relógio dirá  se eu esperar  {offset} minutos
+o que o relógio dirá  se eu esperar  {offset} minutos em {location}
+o que o relógio dirá  se eu esperar  {offset} segundo
+o que o relógio dirá  se eu esperar  {offset} segundo em {location}
+o que o relógio dirá  se eu esperar  {offset} segundos
+o que o relógio dirá  se eu esperar  {offset} segundos em {location}
+o que o relógio dirá em  {offset} hora
+o que o relógio dirá em  {offset} hora em {location}
+o que o relógio dirá em  {offset} horas
+o que o relógio dirá em  {offset} horas em {location}
+o que o relógio dirá em  {offset} minuto
+o que o relógio dirá em  {offset} minuto em {location}
+o que o relógio dirá em  {offset} minutos
+o que o relógio dirá em  {offset} minutos em {location}
+o que o relógio dirá em  {offset} segundo
+o que o relógio dirá em  {offset} segundo em {location}
+o que o relógio dirá em  {offset} segundos
+o que o relógio dirá em  {offset} segundos em {location}
+quando horas isso mostrar depois de {offset} hora
+quando horas isso mostrar depois de {offset} hora em {location}
+quando horas isso mostrar depois de {offset} horas
+quando horas isso mostrar depois de {offset} horas em {location}
+quando horas isso mostrar depois de {offset} minuto
+quando horas isso mostrar depois de {offset} minuto em {location}
+quando horas isso mostrar depois de {offset} minutos
+quando horas isso mostrar depois de {offset} minutos em {location}
+quando horas isso mostrar depois de {offset} segundo
+quando horas isso mostrar depois de {offset} segundo em {location}
+quando horas isso mostrar depois de {offset} segundos
+quando horas isso mostrar depois de {offset} segundos em {location}
+quando horas isso mostrar em {offset} hora
+quando horas isso mostrar em {offset} hora em {location}
+quando horas isso mostrar em {offset} horas
+quando horas isso mostrar em {offset} horas em {location}
+quando horas isso mostrar em {offset} minuto
+quando horas isso mostrar em {offset} minuto em {location}
+quando horas isso mostrar em {offset} minutos
+quando horas isso mostrar em {offset} minutos em {location}
+quando horas isso mostrar em {offset} segundo
+quando horas isso mostrar em {offset} segundo em {location}
+quando horas isso mostrar em {offset} segundos
+quando horas isso mostrar em {offset} segundos em {location}
+quando horas isso mostrar se eu esperar {offset} hora
+quando horas isso mostrar se eu esperar {offset} hora em {location}
+quando horas isso mostrar se eu esperar {offset} horas
+quando horas isso mostrar se eu esperar {offset} horas em {location}
+quando horas isso mostrar se eu esperar {offset} minuto
+quando horas isso mostrar se eu esperar {offset} minuto em {location}
+quando horas isso mostrar se eu esperar {offset} minutos
+quando horas isso mostrar se eu esperar {offset} minutos em {location}
+quando horas isso mostrar se eu esperar {offset} segundo
+quando horas isso mostrar se eu esperar {offset} segundo em {location}
+quando horas isso mostrar se eu esperar {offset} segundos
+quando horas isso mostrar se eu esperar {offset} segundos em {location}
+quando horas isso será depois de {offset} hora
+quando horas isso será depois de {offset} hora em {location}
+quando horas isso será depois de {offset} horas
+quando horas isso será depois de {offset} horas em {location}
+quando horas isso será depois de {offset} minuto
+quando horas isso será depois de {offset} minuto em {location}
+quando horas isso será depois de {offset} minutos
+quando horas isso será depois de {offset} minutos em {location}
+quando horas isso será depois de {offset} segundo
+quando horas isso será depois de {offset} segundo em {location}
+quando horas isso será depois de {offset} segundos
+quando horas isso será depois de {offset} segundos em {location}
+quando horas isso será em {offset} hora
+quando horas isso será em {offset} hora em {location}
+quando horas isso será em {offset} horas
+quando horas isso será em {offset} horas em {location}
+quando horas isso será em {offset} minuto
+quando horas isso será em {offset} minuto em {location}
+quando horas isso será em {offset} minutos
+quando horas isso será em {offset} minutos em {location}
+quando horas isso será em {offset} segundo
+quando horas isso será em {offset} segundo em {location}
+quando horas isso será em {offset} segundos
+quando horas isso será em {offset} segundos em {location}
+quando horas isso será se eu esperar {offset} hora
+quando horas isso será se eu esperar {offset} hora em {location}
+quando horas isso será se eu esperar {offset} horas
+quando horas isso será se eu esperar {offset} horas em {location}
+quando horas isso será se eu esperar {offset} minuto
+quando horas isso será se eu esperar {offset} minuto em {location}
+quando horas isso será se eu esperar {offset} minutos
+quando horas isso será se eu esperar {offset} minutos em {location}
+quando horas isso será se eu esperar {offset} segundo
+quando horas isso será se eu esperar {offset} segundo em {location}
+quando horas isso será se eu esperar {offset} segundos
+quando horas isso será se eu esperar {offset} segundos em {location}
+quando horas isso tornar-se-á depois de {offset} hora
+quando horas isso tornar-se-á depois de {offset} hora em {location}
+quando horas isso tornar-se-á depois de {offset} horas
+quando horas isso tornar-se-á depois de {offset} horas em {location}
+quando horas isso tornar-se-á depois de {offset} minuto
+quando horas isso tornar-se-á depois de {offset} minuto em {location}
+quando horas isso tornar-se-á depois de {offset} minutos
+quando horas isso tornar-se-á depois de {offset} minutos em {location}
+quando horas isso tornar-se-á depois de {offset} segundo
+quando horas isso tornar-se-á depois de {offset} segundo em {location}
+quando horas isso tornar-se-á depois de {offset} segundos
+quando horas isso tornar-se-á depois de {offset} segundos em {location}
+quando horas isso tornar-se-á em {offset} hora
+quando horas isso tornar-se-á em {offset} hora em {location}
+quando horas isso tornar-se-á em {offset} horas
+quando horas isso tornar-se-á em {offset} horas em {location}
+quando horas isso tornar-se-á em {offset} minuto
+quando horas isso tornar-se-á em {offset} minuto em {location}
+quando horas isso tornar-se-á em {offset} minutos
+quando horas isso tornar-se-á em {offset} minutos em {location}
+quando horas isso tornar-se-á em {offset} segundo
+quando horas isso tornar-se-á em {offset} segundo em {location}
+quando horas isso tornar-se-á em {offset} segundos
+quando horas isso tornar-se-á em {offset} segundos em {location}
+quando horas isso tornar-se-á se eu esperar {offset} hora
+quando horas isso tornar-se-á se eu esperar {offset} hora em {location}
+quando horas isso tornar-se-á se eu esperar {offset} horas
+quando horas isso tornar-se-á se eu esperar {offset} horas em {location}
+quando horas isso tornar-se-á se eu esperar {offset} minuto
+quando horas isso tornar-se-á se eu esperar {offset} minuto em {location}
+quando horas isso tornar-se-á se eu esperar {offset} minutos
+quando horas isso tornar-se-á se eu esperar {offset} minutos em {location}
+quando horas isso tornar-se-á se eu esperar {offset} segundo
+quando horas isso tornar-se-á se eu esperar {offset} segundo em {location}
+quando horas isso tornar-se-á se eu esperar {offset} segundos
+quando horas isso tornar-se-á se eu esperar {offset} segundos em {location}
+quando será {offset} horas
+quando será {offset} horas  em {location}
+quando será {offset} horas a partir de agora
+quando será {offset} horas a partir de agora em {location}
+quando será {offset} minutos
+quando será {offset} minutos  em {location}
+quando será {offset} minutos a partir de agora
+quando será {offset} minutos a partir de agora em {location}
+quando será {offset} segundos
+quando será {offset} segundos  em {location}
+quando será {offset} segundos a partir de agora
+quando será {offset} segundos a partir de agora em {location}
+quando serão se eu esperar {offset} hora
+quando serão se eu esperar {offset} hora em {location}
+quando serão se eu esperar {offset} horas
+quando serão se eu esperar {offset} horas em {location}
+quando serão se eu esperar {offset} minuto
+quando serão se eu esperar {offset} minuto em {location}
+quando serão se eu esperar {offset} minutos
+quando serão se eu esperar {offset} minutos em {location}
+quando serão se eu esperar {offset} segundo
+quando serão se eu esperar {offset} segundo em {location}
+quando serão se eu esperar {offset} segundos
+quando serão se eu esperar {offset} segundos em {location}
+quando serão se eu gastar {offset} hora
+quando serão se eu gastar {offset} hora em {location}
+quando serão se eu gastar {offset} horas
+quando serão se eu gastar {offset} horas em {location}
+quando serão se eu gastar {offset} minuto
+quando serão se eu gastar {offset} minuto em {location}
+quando serão se eu gastar {offset} minutos
+quando serão se eu gastar {offset} minutos em {location}
+quando serão se eu gastar {offset} segundo
+quando serão se eu gastar {offset} segundo em {location}
+quando serão se eu gastar {offset} segundos
+quando serão se eu gastar {offset} segundos em {location}
+quando é {offset} horas
+quando é {offset} horas  em {location}
+quando é {offset} horas a partir de agora
+quando é {offset} horas a partir de agora em {location}
+quando é {offset} minutos
+quando é {offset} minutos  em {location}
+quando é {offset} minutos a partir de agora
+quando é {offset} minutos a partir de agora em {location}
+quando é {offset} segundos
+quando é {offset} segundos  em {location}
+quando é {offset} segundos a partir de agora
+quando é {offset} segundos a partir de agora em {location}
+que horas isso mostrar depois de {offset} hora
+que horas isso mostrar depois de {offset} hora em {location}
+que horas isso mostrar depois de {offset} horas
+que horas isso mostrar depois de {offset} horas em {location}
+que horas isso mostrar depois de {offset} minuto
+que horas isso mostrar depois de {offset} minuto em {location}
+que horas isso mostrar depois de {offset} minutos
+que horas isso mostrar depois de {offset} minutos em {location}
+que horas isso mostrar depois de {offset} segundo
+que horas isso mostrar depois de {offset} segundo em {location}
+que horas isso mostrar depois de {offset} segundos
+que horas isso mostrar depois de {offset} segundos em {location}
+que horas isso mostrar em {offset} hora
+que horas isso mostrar em {offset} hora em {location}
+que horas isso mostrar em {offset} horas
+que horas isso mostrar em {offset} horas em {location}
+que horas isso mostrar em {offset} minuto
+que horas isso mostrar em {offset} minuto em {location}
+que horas isso mostrar em {offset} minutos
+que horas isso mostrar em {offset} minutos em {location}
+que horas isso mostrar em {offset} segundo
+que horas isso mostrar em {offset} segundo em {location}
+que horas isso mostrar em {offset} segundos
+que horas isso mostrar em {offset} segundos em {location}
+que horas isso mostrar se eu esperar {offset} hora
+que horas isso mostrar se eu esperar {offset} hora em {location}
+que horas isso mostrar se eu esperar {offset} horas
+que horas isso mostrar se eu esperar {offset} horas em {location}
+que horas isso mostrar se eu esperar {offset} minuto
+que horas isso mostrar se eu esperar {offset} minuto em {location}
+que horas isso mostrar se eu esperar {offset} minutos
+que horas isso mostrar se eu esperar {offset} minutos em {location}
+que horas isso mostrar se eu esperar {offset} segundo
+que horas isso mostrar se eu esperar {offset} segundo em {location}
+que horas isso mostrar se eu esperar {offset} segundos
+que horas isso mostrar se eu esperar {offset} segundos em {location}
+que horas isso será depois de {offset} hora
+que horas isso será depois de {offset} hora em {location}
+que horas isso será depois de {offset} horas
+que horas isso será depois de {offset} horas em {location}
+que horas isso será depois de {offset} minuto
+que horas isso será depois de {offset} minuto em {location}
+que horas isso será depois de {offset} minutos
+que horas isso será depois de {offset} minutos em {location}
+que horas isso será depois de {offset} segundo
+que horas isso será depois de {offset} segundo em {location}
+que horas isso será depois de {offset} segundos
+que horas isso será depois de {offset} segundos em {location}
+que horas isso será em {offset} hora
+que horas isso será em {offset} hora em {location}
+que horas isso será em {offset} horas
+que horas isso será em {offset} horas em {location}
+que horas isso será em {offset} minuto
+que horas isso será em {offset} minuto em {location}
+que horas isso será em {offset} minutos
+que horas isso será em {offset} minutos em {location}
+que horas isso será em {offset} segundo
+que horas isso será em {offset} segundo em {location}
+que horas isso será em {offset} segundos
+que horas isso será em {offset} segundos em {location}
+que horas isso será se eu esperar {offset} hora
+que horas isso será se eu esperar {offset} hora em {location}
+que horas isso será se eu esperar {offset} horas
+que horas isso será se eu esperar {offset} horas em {location}
+que horas isso será se eu esperar {offset} minuto
+que horas isso será se eu esperar {offset} minuto em {location}
+que horas isso será se eu esperar {offset} minutos
+que horas isso será se eu esperar {offset} minutos em {location}
+que horas isso será se eu esperar {offset} segundo
+que horas isso será se eu esperar {offset} segundo em {location}
+que horas isso será se eu esperar {offset} segundos
+que horas isso será se eu esperar {offset} segundos em {location}
+que horas isso tornar-se-á depois de {offset} hora
+que horas isso tornar-se-á depois de {offset} hora em {location}
+que horas isso tornar-se-á depois de {offset} horas
+que horas isso tornar-se-á depois de {offset} horas em {location}
+que horas isso tornar-se-á depois de {offset} minuto
+que horas isso tornar-se-á depois de {offset} minuto em {location}
+que horas isso tornar-se-á depois de {offset} minutos
+que horas isso tornar-se-á depois de {offset} minutos em {location}
+que horas isso tornar-se-á depois de {offset} segundo
+que horas isso tornar-se-á depois de {offset} segundo em {location}
+que horas isso tornar-se-á depois de {offset} segundos
+que horas isso tornar-se-á depois de {offset} segundos em {location}
+que horas isso tornar-se-á em {offset} hora
+que horas isso tornar-se-á em {offset} hora em {location}
+que horas isso tornar-se-á em {offset} horas
+que horas isso tornar-se-á em {offset} horas em {location}
+que horas isso tornar-se-á em {offset} minuto
+que horas isso tornar-se-á em {offset} minuto em {location}
+que horas isso tornar-se-á em {offset} minutos
+que horas isso tornar-se-á em {offset} minutos em {location}
+que horas isso tornar-se-á em {offset} segundo
+que horas isso tornar-se-á em {offset} segundo em {location}
+que horas isso tornar-se-á em {offset} segundos
+que horas isso tornar-se-á em {offset} segundos em {location}
+que horas isso tornar-se-á se eu esperar {offset} hora
+que horas isso tornar-se-á se eu esperar {offset} hora em {location}
+que horas isso tornar-se-á se eu esperar {offset} horas
+que horas isso tornar-se-á se eu esperar {offset} horas em {location}
+que horas isso tornar-se-á se eu esperar {offset} minuto
+que horas isso tornar-se-á se eu esperar {offset} minuto em {location}
+que horas isso tornar-se-á se eu esperar {offset} minutos
+que horas isso tornar-se-á se eu esperar {offset} minutos em {location}
+que horas isso tornar-se-á se eu esperar {offset} segundo
+que horas isso tornar-se-á se eu esperar {offset} segundo em {location}
+que horas isso tornar-se-á se eu esperar {offset} segundos
+que horas isso tornar-se-á se eu esperar {offset} segundos em {location}
+que horas será {offset} horas
+que horas será {offset} horas  em {location}
+que horas será {offset} horas a partir de agora
+que horas será {offset} horas a partir de agora em {location}
+que horas será {offset} minutos
+que horas será {offset} minutos  em {location}
+que horas será {offset} minutos a partir de agora
+que horas será {offset} minutos a partir de agora em {location}
+que horas será {offset} segundos
+que horas será {offset} segundos  em {location}
+que horas será {offset} segundos a partir de agora
+que horas será {offset} segundos a partir de agora em {location}
+que horas serão se eu esperar {offset} hora
+que horas serão se eu esperar {offset} hora em {location}
+que horas serão se eu esperar {offset} horas
+que horas serão se eu esperar {offset} horas em {location}
+que horas serão se eu esperar {offset} minuto
+que horas serão se eu esperar {offset} minuto em {location}
+que horas serão se eu esperar {offset} minutos
+que horas serão se eu esperar {offset} minutos em {location}
+que horas serão se eu esperar {offset} segundo
+que horas serão se eu esperar {offset} segundo em {location}
+que horas serão se eu esperar {offset} segundos
+que horas serão se eu esperar {offset} segundos em {location}
+que horas serão se eu gastar {offset} hora
+que horas serão se eu gastar {offset} hora em {location}
+que horas serão se eu gastar {offset} horas
+que horas serão se eu gastar {offset} horas em {location}
+que horas serão se eu gastar {offset} minuto
+que horas serão se eu gastar {offset} minuto em {location}
+que horas serão se eu gastar {offset} minutos
+que horas serão se eu gastar {offset} minutos em {location}
+que horas serão se eu gastar {offset} segundo
+que horas serão se eu gastar {offset} segundo em {location}
+que horas serão se eu gastar {offset} segundos
+que horas serão se eu gastar {offset} segundos em {location}
+que horas são   depois {offset} hora
+que horas são   depois {offset} hora em {location}
+que horas são   depois {offset} horas
+que horas são   depois {offset} horas em {location}
+que horas são   depois {offset} minuto
+que horas são   depois {offset} minuto em {location}
+que horas são   depois {offset} minutos
+que horas são   depois {offset} minutos em {location}
+que horas são   depois {offset} segundo
+que horas são   depois {offset} segundo em {location}
+que horas são   depois {offset} segundos
+que horas são   depois {offset} segundos em {location}
+que horas são   se eu esperar  {offset} hora
+que horas são   se eu esperar  {offset} hora em {location}
+que horas são   se eu esperar  {offset} horas
+que horas são   se eu esperar  {offset} horas em {location}
+que horas são   se eu esperar  {offset} minuto
+que horas são   se eu esperar  {offset} minuto em {location}
+que horas são   se eu esperar  {offset} minutos
+que horas são   se eu esperar  {offset} minutos em {location}
+que horas são   se eu esperar  {offset} segundo
+que horas são   se eu esperar  {offset} segundo em {location}
+que horas são   se eu esperar  {offset} segundos
+que horas são   se eu esperar  {offset} segundos em {location}
+que horas são  em  {offset} hora
+que horas são  em  {offset} hora em {location}
+que horas são  em  {offset} horas
+que horas são  em  {offset} horas em {location}
+que horas são  em  {offset} minuto
+que horas são  em  {offset} minuto em {location}
+que horas são  em  {offset} minutos
+que horas são  em  {offset} minutos em {location}
+que horas são  em  {offset} segundo
+que horas são  em  {offset} segundo em {location}
+que horas são  em  {offset} segundos
+que horas são  em  {offset} segundos em {location}
+que horas é {offset} horas
+que horas é {offset} horas  em {location}
+que horas é {offset} horas a partir de agora
+que horas é {offset} horas a partir de agora em {location}
+que horas é {offset} minutos
+que horas é {offset} minutos  em {location}
+que horas é {offset} minutos a partir de agora
+que horas é {offset} minutos a partir de agora em {location}
+que horas é {offset} segundos
+que horas é {offset} segundos  em {location}
+que horas é {offset} segundos a partir de agora
+que horas é {offset} segundos a partir de agora em {location}

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
     packages=[SKILL_PKG],
     include_package_data=True,
     install_requires=get_requirements("requirements.txt"),
-    extras_require={'test': ['ovoscope>=1.5.0a1', 'padacioso>=1.1.1a1']},
+    extras_require={'test': ['ovoscope>=1.5.0a1', 'padacioso>=1.1.1a1', 'ovos-spec-tools>=1.5.0a1']},
     keywords='ovos skill plugin',
     entry_points={'ovos.plugin.skill': PLUGIN_ENTRY_POINT}
 )

--- a/test/unittests/test_locale_templates.py
+++ b/test/unittests/test_locale_templates.py
@@ -1,0 +1,59 @@
+"""Regression tests for the locale template resources.
+
+Every non-comment line in the ``.intent``, ``.voc`` and ``.entity`` files must
+expand into valid samples, and intent slot names must come from the canonical
+inventory the skill handlers read from ``message.data``.
+"""
+import re
+from os.path import dirname, join
+from pathlib import Path
+from unittest import TestCase
+
+from ovos_spec_tools.expansion import expand
+
+LOCALE_DIR = Path(join(dirname(dirname(dirname(__file__))), "locale"))
+TEMPLATE_SUFFIXES = (".intent", ".voc", ".entity")
+# slot names the intent handlers read from message.data
+CANONICAL_SLOTS = {"location", "offset", "date", "weekday"}
+
+
+def iter_template_lines():
+    for path in sorted(LOCALE_DIR.rglob("*")):
+        if path.suffix not in TEMPLATE_SUFFIXES:
+            continue
+        for lineno, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), start=1):
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            yield path, lineno, stripped
+
+
+class TestLocaleTemplates(TestCase):
+
+    def test_locale_dir_exists(self):
+        self.assertTrue(LOCALE_DIR.is_dir())
+        self.assertTrue(any(iter_template_lines()))
+
+    def test_every_template_line_expands(self):
+        failures = []
+        for path, lineno, line in iter_template_lines():
+            try:
+                expand(line)
+            except Exception as e:
+                rel = path.relative_to(LOCALE_DIR)
+                failures.append(f"{rel}:{lineno}: {line!r} -> {e}")
+        self.assertEqual(failures, [],
+                         "malformed template lines:\n" + "\n".join(failures))
+
+    def test_intent_slot_names_are_canonical(self):
+        failures = []
+        for path, lineno, line in iter_template_lines():
+            if path.suffix != ".intent":
+                continue
+            for slot in re.findall(r"\{([^{}]+)\}", line):
+                if slot.strip() not in CANONICAL_SLOTS:
+                    rel = path.relative_to(LOCALE_DIR)
+                    failures.append(f"{rel}:{lineno}: {{{slot}}}")
+        self.assertEqual(failures, [],
+                         "non-canonical intent slot names:\n" + "\n".join(failures))


### PR DESCRIPTION
## Summary
- Restore canonical slot names in translated intent files: `{Offset}`/`{deslocamento}` → `{offset}`, `{Datum}`/`{dato}`/`{data}` → `{date}`, `{Ort}`/`{localización}`/`{lokation}`/`{local}`/`{locatie}` → `{location}`. Slot names are identifiers the intent handlers read from `message.data`, so they must match across languages.
- Close truncated slot braces (`{location` → `{location}`) in pl-PL.
- Separate adjacent slots (`{location}  {offset}`) with the connecting word used by parallel templates in the same file (pl-PL, cs-CZ), restore a dropped `{offset}` slot where sibling lines make the wording unambiguous, and fix an unbalanced alternation in es-ES.
- Delete the 42 lines that cannot be expanded into valid samples (repeated slots in cs-CZ/hu-HU garbled templates).
- Add a regression test that walks `locale/**/*.intent|voc|entity` and asserts every non-comment line expands via `ovos_spec_tools.expansion.expand` and that intent slot names come from the canonical inventory.

## Testing
- `test/unittests` and `test/end2end` pass in a fresh venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)