### PR TITLE
fix: rename entry-point group to opm.skill

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,5 +86,5 @@ setup(
     install_requires=get_requirements("requirements.txt"),
     extras_require={'test': ['ovoscope>=1.5.0a1', 'padacioso>=1.1.1a1', 'ovos-spec-tools>=1.5.0a1']},
     keywords='ovos skill plugin',
-    entry_points={'ovos.plugin.skill': PLUGIN_ENTRY_POINT}
+    entry_points={'opm.skill': PLUGIN_ENTRY_POINT}
 )


### PR DESCRIPTION
Rename the packaging entry-point group from the deprecated `ovos.plugin.skill` to `opm.skill`. OPM still loads the skill under the old group but logs a deprecation warning on every boot; this silences it. The entry-point value is unchanged and still points at the SkillClass.