### PR TITLE
fix(da-DK): correct timezone value typos, add missing {location} intent variants

### DIFF
--- a/locale/da-DK/intents/what.time.is.it.intent
+++ b/locale/da-DK/intents/what.time.is.it.intent
@@ -1,11 +1,22 @@
 Hvad er klokken
+Hvad er klokken i {location}
 Hvad er klokken nu
+Hvad er klokken nu i {location}
 klokken  nu
+klokken  nu i {location}
 klokken  nu tak
+klokken  nu tak i {location}
 klokken lige nu
+klokken lige nu i {location}
 klokken lige nu tak
+klokken lige nu tak i {location}
 klokken nu
+klokken nu i {location}
 tid  nu
+tid  nu i {location}
 tid  nu tak
+tid  nu tak i {location}
 tid lige nu
+tid lige nu i {location}
 tid lige nu tak
+tid lige nu tak i {location}

--- a/locale/da-DK/timezone.value
+++ b/locale/da-DK/timezone.value
@@ -1,11 +1,11 @@
 # This is a translatable list of values and timezones
-Kina, ETC/GMT+8
+Kina, Etc/GMT+8
 Kansas City, US/Central
 Nordamerikas centrale tidszone, US/Central
 Nordamerikansk central tid, US/Central
-Vest Amerikansk tidszone, US(Pacifik-New
-Vestamerikanslk tid, US(Pacific-New
+Vest Amerikansk tidszone, US/Pacific-New
+Vestamerikansk tid, US/Pacific-New
 Østamerikansk tid, US/Eastern
-Amerikansk østkøst tidszone, US/Eastern
+Amerikansk østkyst tidszone, US/Eastern
 Amerikansk østkyst, US/Eastern
-Amerikansk æstkyst tid, US/Eastern
+Amerikansk østkyst tid, US/Eastern


### PR DESCRIPTION
Found via ovos-localize validation while doing a general da-DK translation review.

## timezone.value
Several typos broke the literal system value matching:
- `ETC/GMT+8` -> `Etc/GMT+8` (wrong case)
- `US(Pacifik-New` / `US(Pacific-New` -> `US/Pacific-New` (slash corrupted to a parenthesis, plus a spelling slip)
- `Amerikansk østkøst` / `æstkyst` -> `østkyst` (typos for the Danish word for "coast")

## what.time.is.it.intent
Only had the bare "what time is it" templates (11 lines), missing every `{location}`-parameterized variant entirely (the English source has one for each) - meaning it was impossible to ask what time it is in a specific place in Danish. Added the missing `{location}` variant for each existing line.

Note: the same missing-`{location}` pattern shows up in several other languages in this skill, including sv-SE/sv-FI - not Danish-specific, flagging for whoever gets to those.