### PR TITLE
fix: negative leap-year dialogs name the queried year

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -761,7 +761,7 @@ class TimeSkill(OVOSSkill):
                                   {"year": next_year})
             else:
                 self.speak_dialog("leap.year.either.no",
-                                  {"year": get_next_leap_year(next_year + 1)})
+                                  {"year": get_next_leap_year(next_year)})
             return
 
         if scope == "next":
@@ -769,7 +769,7 @@ class TimeSkill(OVOSSkill):
                 self.speak_dialog("leap.year.next.yes", {"year": next_year})
             else:
                 self.speak_dialog("leap.year.next.no",
-                                  {"year": get_next_leap_year(next_year)})
+                                  {"year": next_year})
             return
 
         if calendar.isleap(current_year):
@@ -777,7 +777,7 @@ class TimeSkill(OVOSSkill):
                               {"year": current_year})
         else:
             self.speak_dialog("leap.year.current.no",
-                              {"year": get_next_leap_year(current_year)})
+                              {"year": current_year})
 
     ######################################################################
     # GUI / Faceplate

--- a/test/unittests/test_leap_year_dialog.py
+++ b/test/unittests/test_leap_year_dialog.py
@@ -1,0 +1,82 @@
+"""Regression test for the is.leap.year.intent dialog-data bug.
+
+Bug: when the queried year was NOT a leap year, the "no" dialogs were fed
+``get_next_leap_year(...)`` instead of the actually-queried year, so e.g.
+"is 2025 a leap year" spoke "No, 2028 is not a leap year" -- doubly wrong,
+since the dialog template says "{year} is not a leap year" but named the
+next leap year instead of the queried one.
+"""
+import datetime
+import unittest
+from unittest.mock import patch
+
+from ovos_utils.messagebus import FakeBus
+
+from ovos_skill_date_time import TimeSkill
+
+SKILL_ID = "ovos-skill-date-time.openvoiceos"
+
+
+class TestLeapYearDialog(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.skill = TimeSkill()
+        cls.skill._startup(FakeBus(), SKILL_ID)
+
+    def _run(self, utterance: str, fixed_now: datetime.datetime):
+        with patch.object(self.skill, "get_datetime", return_value=fixed_now), \
+             patch.object(self.skill, "speak_dialog") as speak_dialog:
+            self.skill.handle_is_leap_year(
+                type("Msg", (), {"data": {"utterance": utterance}})()
+            )
+        return speak_dialog
+
+    def test_non_leap_current_year_speaks_queried_year(self):
+        # 2025 is not a leap year; the "no" dialog must name 2025, not the
+        # next leap year (2028).
+        now = datetime.datetime(2025, 6, 1)
+        speak_dialog = self._run("is this year a leap year", now)
+        speak_dialog.assert_called_once_with(
+            "leap.year.current.no", {"year": 2025}
+        )
+
+    def test_leap_current_year_still_speaks_positive_dialog(self):
+        # 2024 is a leap year; behavior must remain unchanged.
+        now = datetime.datetime(2024, 6, 1)
+        speak_dialog = self._run("is this year a leap year", now)
+        speak_dialog.assert_called_once_with(
+            "leap.year.current.yes", {"year": 2024}
+        )
+
+    def test_non_leap_next_year_speaks_queried_year(self):
+        # queried from 2025 -> next_year 2026, not a leap year; dialog must
+        # name 2026, not some further-future leap year.
+        now = datetime.datetime(2025, 6, 1)
+        speak_dialog = self._run("is next year a leap year", now)
+        speak_dialog.assert_called_once_with(
+            "leap.year.next.no", {"year": 2026}
+        )
+
+    def test_leap_next_year_still_speaks_positive_dialog(self):
+        # queried from 2023 -> next_year 2024, a leap year.
+        now = datetime.datetime(2023, 6, 1)
+        speak_dialog = self._run("is next year a leap year", now)
+        speak_dialog.assert_called_once_with(
+            "leap.year.next.yes", {"year": 2024}
+        )
+
+    def test_non_leap_either_scope_names_the_true_next_leap_year(self):
+        # queried from 2026 -> current_year 2026, next_year 2027, neither
+        # leap; the true next leap year after 2027 is 2028. The buggy code
+        # asked get_next_leap_year(next_year + 1) = get_next_leap_year(2028),
+        # which -- since get_next_leap_year returns the next leap year
+        # STRICTLY AFTER its argument -- skips 2028 and answers 2032.
+        now = datetime.datetime(2026, 6, 1)
+        speak_dialog = self._run("is this year a leap year or next", now)
+        speak_dialog.assert_called_once_with(
+            "leap.year.either.no", {"year": 2028}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

`handle_is_leap_year` had three related off-by-year bugs in its negative answers. Asking "is 2025 a leap year" answered "No, 2028 is not a leap year" — it fed the *next* leap year into the dialog about the *current* year, so the wrong year appeared twice. The same mistake happened for the next-year case. A third bug affected the "neither year is leap" case: it computed the next leap year strictly after `next_year + 1`, which skips a leap year whenever `next_year + 1` is itself leap — asked in 2026 it answered 2032 instead of the correct 2028.

The first two were found during the initial fix; the third only surfaced during an independent adversarial review of this PR, which also re-checked the red/green evidence for the first two and confirmed it was correct.

The fix interpolates the actual queried year into the two "no" dialogs, and corrects the either-scope calculation so it looks for the next leap year after `next_year` instead of after `next_year + 1`.

`test/unittests/test_leap_year_dialog.py` asserts the exact dialog and year data passed to `speak_dialog`. Reverting the first two fixes fails 2 of 4 tests with the wrong year in the dialog call; reverting the third fails the either-scope test the same way. All five tests pass with the fix in place. The wider `test/unittests/` suite is 11 passed / 1 failed in my dev environment, but that one failure (`test_skill_loading.py::test_from_loader`) didn't reproduce in a clean venv, so it looks like something specific to my setup rather than caused by this change.

This branches directly off `origin/dev`, not off the open #264 entity-wiring draft, and only touches these leap-year dialog bugs, so it can merge on its own regardless of what happens with #264.
